### PR TITLE
Add support for CLI flags

### DIFF
--- a/.github/workflows/release-ui-assets.yaml
+++ b/.github/workflows/release-ui-assets.yaml
@@ -80,7 +80,7 @@ jobs:
           asset_content_type: application/zip
       - name: Generate embedded assets
         run: |
-          BUILD_TAG="dashboard_ui" scripts/embed_ui_assets.sh
+          NO_ASSET_BUILD_TAG=1 scripts/embed_ui_assets.sh
           cp pkg/uiserver/embedded_assets_handler.go embedded_assets_handler.go
       - name: Pack embedded assets
         if: github.event_name == 'push'

--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -11,31 +11,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
-
-import (
-	"log"
-	"net/http"
-
-	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver"
-	"github.com/pingcap-incubator/tidb-dashboard/pkg/swaggerserver"
-	"github.com/pingcap-incubator/tidb-dashboard/pkg/uiserver"
-)
-
 // @title Dashboard API
 // @version 1.0
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @BasePath /dashboard/api
 
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/swaggerserver"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/uiserver"
+)
+
+type DashboardCLIConfig struct {
+	listenHost string
+	listenPort int
+}
+
 func main() {
-	addr := ":12333"
+	cliConfig := &DashboardCLIConfig{}
+	coreConfig := &config.Config{}
+
+	flag.StringVar(&cliConfig.listenHost, "host", "0.0.0.0", "The listen address of the Dashboard Server")
+	flag.IntVar(&cliConfig.listenPort, "port", 12333, "The listen port of the Dashboard Server")
+	flag.StringVar(&coreConfig.DataDir, "data-dir", "/tmp/dashboard-data", "Path to the Dashboard Server data directory")
+	flag.StringVar(&coreConfig.PDEndPoint, "pd", "http://127.0.0.1:2379", "The PD endpoint that Dashboard Server connects to")
+	flag.Parse()
 
 	mux := http.NewServeMux()
 	mux.Handle("/dashboard/", http.StripPrefix("/dashboard", uiserver.Handler()))
-	mux.Handle("/dashboard/api/", apiserver.Handler("/dashboard/api"))
+	mux.Handle("/dashboard/api/", apiserver.Handler("/dashboard/api", coreConfig))
 	mux.Handle("/dashboard/api/swagger/", swaggerserver.Handler())
 
-	log.Println("Dashboard server listen on", addr)
-	log.Fatal(http.ListenAndServe(addr, mux))
+	listenAddr := fmt.Sprintf("%s:%d", cliConfig.listenHost, cliConfig.listenPort)
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Dashboard server is listening at %s\n", listenAddr)
+	log.Printf("UI:      http://127.0.0.1:%d/dashboard/\n", cliConfig.listenPort)
+	log.Printf("API:     http://127.0.0.1:%d/dashboard/api/\n", cliConfig.listenPort)
+	log.Printf("Swagger: http://127.0.0.1:%d/dashboard/api/swagger/\n", cliConfig.listenPort)
+	log.Fatal(http.Serve(listener, mux))
 }

--- a/pkg/apiserver/foo/foo.go
+++ b/pkg/apiserver/foo/foo.go
@@ -14,9 +14,23 @@
 package foo
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
 )
+
+type Service struct {
+}
+
+func NewService(config *config.Config) *Service {
+	return &Service{}
+}
+
+func (s *Service) Register(r *gin.RouterGroup) {
+	endpoint := r.Group("/foo")
+	endpoint.GET("/:name", s.greetHandler)
+}
 
 // @Summary Greet
 // @Description Hello world!
@@ -25,12 +39,7 @@ import (
 // @Param name path string true "Name"
 // @Success 200 {string} string
 // @Router /foo/{name} [get]
-func greetHandler(c *gin.Context) {
+func (s *Service) greetHandler(c *gin.Context) {
 	name := c.Param("name")
 	c.String(http.StatusOK, "Hello %s", name)
-}
-
-func RegisterService(r *gin.RouterGroup) {
-	endpoint := r.Group("/foo")
-	endpoint.GET("/:name", greetHandler)
 }

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -25,18 +25,26 @@ type Info struct {
 	PDEndPoint string `json:"pd_end_point"`
 }
 
+type Service struct {
+	config *config.Config
+}
+
+func NewService(config *config.Config) *Service {
+	return &Service{config: config}
+}
+
+func (s *Service) Register(r *gin.RouterGroup) {
+	endpoint := r.Group("/info")
+	endpoint.GET("/", s.infoHandler)
+}
+
 // @Summary Dashboard info
 // @Description Get information about the dashboard service.
 // @Produce json
 // @Success 200 {object} Info
 // @Router /info [get]
-func infoHandler(c *gin.Context) {
+func (s *Service) infoHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, Info{
-		PDEndPoint: config.GetGlobalConfig().PDEndPoint,
+		PDEndPoint: s.config.PDEndPoint,
 	})
-}
-
-func RegisterService(r *gin.RouterGroup) {
-	endpoint := r.Group("/info")
-	endpoint.GET("/", infoHandler)
 }

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -11,30 +11,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package apiserver
+package info
 
 import (
 	"net/http"
 
-	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/foo"
-	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/info"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
 )
 
-func Handler(apiPrefix string, coreConfig *config.Config) http.Handler {
-	config.SetGlobalConfig(coreConfig)
+type Info struct {
+	Version    string `json:"version"`
+	PDEndPoint string `json:"pd_end_point"`
+}
 
-	gin.SetMode(gin.ReleaseMode)
+// @Summary Dashboard info
+// @Description Get information about the dashboard service.
+// @Produce json
+// @Success 200 {object} Info
+// @Router /info [get]
+func infoHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, Info{
+		PDEndPoint: config.GetGlobalConfig().PDEndPoint,
+	})
+}
 
-	r := gin.New()
-	r.Use(cors.Default())
-	r.Use(gin.Recovery())
-	endpoint := r.Group(apiPrefix)
-
-	foo.RegisterService(endpoint)
-	info.RegisterService(endpoint)
-
-	return r
+func RegisterService(r *gin.RouterGroup) {
+	endpoint := r.Group("/info")
+	endpoint.GET("/", infoHandler)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,29 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+var globalConfig *Config = nil
+
+type Config struct {
+	DataDir    string
+	PDEndPoint string
+}
+
+func SetGlobalConfig(config *Config) {
+	globalConfig = config
+}
+
+func GetGlobalConfig() *Config {
+	return globalConfig
+}

--- a/scripts/embed_ui_assets.sh
+++ b/scripts/embed_ui_assets.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 # This script embeds UI assets into Golang source file. UI assets must be already built
-# before calling this script
+# before calling this script.
+#
+# Available flags:
+# NO_ASSET_BUILD_TAG=1
+#   No build tags will be included in the generated source code.
+# ASSET_BUILD_TAG=X
+#   Customize the build tag of the generated source code. If unspecified, build tag will be "ui_server".
 
 set -euo pipefail
 
@@ -10,12 +16,16 @@ PROJECT_DIR="$(dirname "$DIR")"
 
 # See https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
-cd $PROJECT_DIR
+cd "$PROJECT_DIR"
 
 export GOBIN=$PROJECT_DIR/bin
 export PATH=$GOBIN:$PATH
 
-: "${BUILD_TAG:=ui_server}"
+if [ "${NO_ASSET_BUILD_TAG:-}" = "1" ]; then
+  BUILD_TAG_PARAMETER=""
+else
+  BUILD_TAG_PARAMETER="-tags ${ASSET_BUILD_TAG:-ui_server}"
+fi
 
 echo "+ Preflight check"
 if [ ! -d "ui/build" ]; then
@@ -28,7 +38,8 @@ go install github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
 go install github.com/go-bindata/go-bindata/go-bindata
 
 echo "+ Embed UI assets"
-go-bindata-assetfs -pkg uiserver -prefix ui -tags $BUILD_TAG ui/build/...
+
+go-bindata-assetfs -pkg uiserver -prefix ui $BUILD_TAG_PARAMETER ui/build/...
 HANDLER_PATH=pkg/uiserver/embedded_assets_handler.go
 mv bindata_assetfs.go $HANDLER_PATH
 echo "  - Assets handler written to $HANDLER_PATH"


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

Support specifying some CLI flags like listen host, listen port, data dir and pd address.

PD address is also available via `/api/info` so that front-end can connect to PD directly.