### PR TITLE
Fix language fallback and auto detection

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/ui/src/utils/i18n.js
+++ b/ui/src/utils/i18n.js
@@ -3,32 +3,30 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import _ from 'lodash';
 
-const resources = {
-  en: {
-    translation: {},
-  },
-  zh_CN: {
-    translation: {},
-  },
-};
+const resources = {};
+const languages = ['en', 'zh_CN'];
 
 function loadResource(res) {
-  _.merge(resources, {
-    en: {
-      translation: res.en,
-    },
-    zh_CN: {
-      translation: res.zh_CN,
-    },
+  languages.forEach(lang => {
+    _.merge(resources, { [lang]: { translation: res[lang] } });
   });
 }
 
 function initFromResources() {
+  // Resource languages are like `zh_CN` for easier writing.
+  // However we need to change them to `zh-CN` to follow IETF language codes.
+  const r = _(resources)
+    .toPairs()
+    .map(([key, value]) => [key.replace(/_/g, '-'), value])
+    .fromPairs()
+    .value();
+
   i18n
     .use(LanguageDetector)
     .use(initReactI18next)
     .init({
-      resources,
+      resources: r,
+      fallbackLng: 'en',
       interpolation: {
         escapeValue: false,
       },


### PR DESCRIPTION
Previously when browser is in simplified chinese language, the detected language code is `zh-CN`. However our language code is `zh_CN`, which result in translation keys not correctly translated.

Now fallback language has been added, and language code is changed to `zh-CN`.