### PR TITLE
clusterinfo: Fix ip and port error

### DIFF
--- a/pkg/apiserver/clusterinfo/service.go
+++ b/pkg/apiserver/clusterinfo/service.go
@@ -91,7 +91,7 @@ func (s *Service) deleteTiDBTopologyHandler(c *gin.Context) {
 // @Description Get information about the dashboard topology.
 // @Produce json
 // @Success 200 {object} clusterinfo.ClusterInfo
-// @Router /topology [get]
+// @Router /topology/ [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) topologyHandler(c *gin.Context) {

--- a/pkg/utils/clusterinfo/fetcher.go
+++ b/pkg/utils/clusterinfo/fetcher.go
@@ -340,17 +340,7 @@ func parseHostAndPortFromAddressURL(urlString string) (string, uint, error) {
 	if err != nil {
 		return "", 0, err
 	}
-	// u.Host maybe host or host:port, if it's host:port
-	// ip need to be extract from u.Host
-	host := u.Host
-	if strings.Contains(u.Host, ":") {
-		h, _, err := parseHostAndPortFromAddress(u.Host)
-		if err != nil {
-			return "", 0, err
-		}
-		host = h
-	}
-	return host, uint(port), nil
+	return u.Hostname(), uint(port), nil
 }
 
 func storeStateToStatus(state string) ComponentStatus {

--- a/pkg/utils/clusterinfo/fetcher.go
+++ b/pkg/utils/clusterinfo/fetcher.go
@@ -340,7 +340,17 @@ func parseHostAndPortFromAddressURL(urlString string) (string, uint, error) {
 	if err != nil {
 		return "", 0, err
 	}
-	return u.Host, uint(port), nil
+	// u.Host maybe host or host:port, if it's host:port
+	// ip need to be extract from u.Host
+	host := u.Host
+	if strings.Contains(u.Host, ":") {
+		h, _, err := parseHostAndPortFromAddress(u.Host)
+		if err != nil {
+			return "", 0, err
+		}
+		host = h
+	}
+	return host, uint(port), nil
 }
 
 func storeStateToStatus(state string) ComponentStatus {


### PR DESCRIPTION
Previous pr uses `Url.Host` to get ip, and there was a problem that it returns ip:port. This pr fix that problem.

Signed-off-by: mapleFU <1506118561@qq.com>