### PR TITLE
clusterinfo: Fix error usage of node count in ClusterInfoTable

### DIFF
--- a/ui/src/apps/clusterInfo/components/ClusterInfoTable.js
+++ b/ui/src/apps/clusterInfo/components/ClusterInfoTable.js
@@ -63,9 +63,10 @@ function pushNodes(key, cluster, dataSource) {
     cluster[key] !== null &&
     cluster[key].err === null
   ) {
+    const nodes = cluster[key].nodes;
     dataSource.push({
-      address: key + '(' + cluster.tidb.nodes.length + ')',
-      children: cluster[key].nodes.map((n, index) => wrapNode(n, key, index))
+      address: key + '(' + nodes.length + ')',
+      children: nodes.map((n, index) => wrapNode(n, key, index))
     })
   }
 }


### PR DESCRIPTION
Previous pr just count TiDB numbers in all kinds of nodes, this pr changes it to the right data.

Signed-off-by: mapleFU <1506118561@qq.com>