### PR TITLE
Add error table to make err happend in report's generating process imported to a table

### DIFF
--- a/pkg/apiserver/diagnose/diagnose.go
+++ b/pkg/apiserver/diagnose/diagnose.go
@@ -83,12 +83,7 @@ func (s *Service) genReportHandler(c *gin.Context) {
 		return
 	}
 
-	tables, errs := GetReportTablesForDisplay(startTime, endTime, db)
-	if len(errs) > 0 {
-		_ = c.Error(errs[0])
-		return
-	}
-
+	tables := GetReportTablesForDisplay(startTime, endTime, db)
 	content, err := json.Marshal(tables)
 	if err != nil {
 		_ = c.Error(err)

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -134,7 +134,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		GetPDCurrentConfig,
 		GetTiKVCurrentConfig,
 	}
-	
+
 	tables := make([]*TableDef, 0, len(funcs))
 	var errRows []TableRowDef
 	for _, f := range funcs {
@@ -142,7 +142,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		if err != nil {
 			category := ""
 			if tbl.Category != nil {
-				category = strings.Join(tbl.Category, ",")
+				category = tbl.Category[0]
 			}
 			errRows = append(errRows, TableRowDef{
 				Values: []string{category, tbl.Title, err.Error()},

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -142,7 +142,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		if err != nil {
 			category := ""
 			if tbl.Category != nil {
-				category = tbl.Category[0]
+				category = strings.Join(tbl.Category, ",")
 			}
 			errRows = append(errRows, TableRowDef{
 				Values: []string{category, tbl.Title, err.Error()},

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -134,6 +134,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		GetPDCurrentConfig,
 		GetTiKVCurrentConfig,
 	}
+	
 	tables := make([]*TableDef, 0, len(funcs))
 	var errRows []TableRowDef
 	for _, f := range funcs {

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -60,7 +60,7 @@ const (
 	CategoryPD       = "PD"
 	CategoryTiKV     = "TiKV"
 	CategoryConfig   = "config"
-	CategoryError    = "err"
+	CategoryError    = "s/err/error"
 )
 
 func GetReportTablesForDisplay(startTime, endTime string, db *gorm.DB) []*TableDef {
@@ -141,7 +141,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		if err != nil {
 			category := ""
 			if tbl.Category != nil {
-				category = tbl.Category[0]
+				category = strings.Join(tbl.Category,",")
 			}
 			errRows = append(errRows, TableRowDef{
 				Values: []string{category, tbl.Title, err.Error()},

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -162,7 +162,7 @@ func GenerateReportError(errRows []TableRowDef) *TableDef {
 		CommentEN: "",
 		CommentCN: "",
 		Column:    []string{"CATEGORY", "TITLE", "ERROR"},
-		Rows: errRows,
+		Rows:      errRows,
 	}
 }
 

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -141,7 +141,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		if err != nil {
 			category := ""
 			if tbl.Category != nil {
-				category = strings.Join(tbl.Category,",")
+				category = strings.Join(tbl.Category, ",")
 			}
 			errRows = append(errRows, TableRowDef{
 				Values: []string{category, tbl.Title, err.Error()},

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -60,7 +60,7 @@ const (
 	CategoryPD       = "PD"
 	CategoryTiKV     = "TiKV"
 	CategoryConfig   = "config"
-	CategoryError    = "s/err/error"
+	CategoryError    = "error"
 )
 
 func GetReportTablesForDisplay(startTime, endTime string, db *gorm.DB) []*TableDef {

--- a/pkg/apiserver/diagnose/report_test.go
+++ b/pkg/apiserver/diagnose/report_test.go
@@ -26,11 +26,10 @@ func (t *testReportSuite) TestReport(c *C) {
 	startTime := "2020-02-27 19:20:23"
 	endTime := "2020-02-27 21:20:23"
 
-	tables, errs := GetReportTablesForDisplay(startTime, endTime, cli)
+	tables := GetReportTablesForDisplay(startTime, endTime, cli)
 	for _, tbl := range tables {
 		printRows(tbl)
 	}
-	c.Assert(errs, HasLen, 0)
 }
 
 func (t *testReportSuite) TestGetTable(c *C) {


### PR DESCRIPTION
before: the error happend in generating report would stop the generating process.
this pr: these error would be imported to a table.

change a table's return err for test: 
![image](https://user-images.githubusercontent.com/30926443/75679370-72f48c80-5cca-11ea-8e1f-5c20b63ed6f2.png)
