### PR TITLE
build: remove installing npm packages from GitHub Packages

### DIFF
--- a/.github/workflows/release-ui-assets.yaml
+++ b/.github/workflows/release-ui-assets.yaml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.5'

--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ A standalone TiDB Dashboard Server contains the following components:
 - Optional: [Node.js](https://nodejs.org/) 12+ and [yarn](https://yarnpkg.com/) if you want to build
   the UI.
 
-  **IMPORTANT**: TiDB Dashboard uses packages from GitHub Packages. You need to [configure the `~/.npmrc`](https://github.com/pingcap-incubator/pd-client-js#install)
-  in order to install these packages.
-
 ### Build Instructions
 
 #### API Only

--- a/ui/.yarnrc
+++ b/ui/.yarnrc
@@ -1,2 +1,0 @@
-"@pingcap-incubator:registry" "https://npm.pkg.github.com"
-"@baurine:registry" "https://npm.pkg.github.com"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1153,9 +1153,9 @@
     to-fast-properties "^2.0.0"
 
 "@baurine/grafana-value-formats@^0.1.1":
-  version "0.1.1"
-  resolved "https://npm.pkg.github.com/download/@baurine/grafana-value-formats/0.1.1/35ae41f50724009ae383412b6d39fb7e87620b3b17c2467bdfbf5d72c60e636e#ee5dabfc2bb59e148e6304e5d272c2f40fecbefc"
-  integrity sha512-TpdWQmjlIvHPAx5lWwr6CAgPfOCM+oTVv2zn1hNKriBbM4KpHbiMqkXpzxMbC9XvgtCjHJWSJh+YNCNWPibunw==
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@baurine/grafana-value-formats/-/grafana-value-formats-0.1.2.tgz#c7bfefa4a81d43099101cd389a83eb45cbb5653f"
+  integrity sha512-P6OPC4LyQmysSYyY2n6n6ZcxdvmUsJ2O0RvLipsReLWZUzYQaQRDi+dKUDCFJgf9A2Mf3mLWacVEM+DsvHf/cQ==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
Because I published the [grafana-value-formats](https://www.npmjs.com/package/@baurine/grafana-value-formats) lib to npm registry as well, so now we can remove the setting to install from GitHub Packages.