### PR TITLE
diagnosis: fix miss bracket syntax error

### DIFF
--- a/pkg/apiserver/diagnose/templates.go
+++ b/pkg/apiserver/diagnose/templates.go
@@ -78,7 +78,7 @@ const TemplateIndex = `
             btn.onclick = function () {
               const curRow = btn.getAttribute('data-row')
               const tbodyEl = btn.parentNode.parentNode.parentNode
-              const subValueRows = tbodyEl.querySelectorAll('tr[data-row="' + curRow + ''"]')
+              const subValueRows = tbodyEl.querySelectorAll('tr[data-row="' + curRow + '"]')
               subValueRows.forEach(row => row.classList.toggle('fold'))
 
               if (btn.innerHTML === 'expand') {


### PR DESCRIPTION
This PR is to fix the browser reported "Uncaught SyntaxError: missing ) after argument list" error, this error makes the "expand" button doesn't work in the diagnosis report page.