### PR TITLE
cmd/tidb-dashboard: replace flag with pflag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ The format can be described more formally as follows:
 
 The first line is the subject and should be no longer than 50 characters, the other lines should be wrapped at 72 characters (see [this blog post](https://preslav.me/2015/02/21/what-s-with-the-50-72-rule/) for why).
 
-If the change affects more than one subsystem, you can use comma to separate them like `keyvis`.
+If the change affects more than one subsystem, you can use comma to separate them like `keyviz`.
 
 If the change affects many subsystems, you can use `*` instead, like `*:`.
 

--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -24,7 +24,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,6 +37,8 @@ import (
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
@@ -77,9 +78,12 @@ func NewCLIConfig() *DashboardCLIConfig {
 	flag.StringVar(&cfg.CoreConfig.PDEndPoint, "pd", "http://127.0.0.1:2379", "The PD endpoint that Dashboard Server connects to")
 	flag.BoolVar(&cfg.EnableDebugLog, "debug", false, "Enable debug logs")
 	// debug for keyvisual
-	// TODO: Hide help information
+	// Hide help information
 	flag.Int64Var(&cfg.KVFileStartTime, "keyvis-file-start", 0, "(debug) start time for file range in file mode")
 	flag.Int64Var(&cfg.KVFileEndTime, "keyvis-file-end", 0, "(debug) end time for file range in file mode")
+
+	_ = flag.CommandLine.MarkHidden("keyvis-file-start")
+	_ = flag.CommandLine.MarkHidden("keyvis-file-end")
 
 	flag.Parse()
 

--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -35,10 +35,9 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/pingcap/log"
+	flag "github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	flag "github.com/spf13/pflag"
 
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
@@ -77,13 +76,12 @@ func NewCLIConfig() *DashboardCLIConfig {
 	flag.StringVar(&cfg.CoreConfig.DataDir, "data-dir", "/tmp/dashboard-data", "Path to the Dashboard Server data directory")
 	flag.StringVar(&cfg.CoreConfig.PDEndPoint, "pd", "http://127.0.0.1:2379", "The PD endpoint that Dashboard Server connects to")
 	flag.BoolVar(&cfg.EnableDebugLog, "debug", false, "Enable debug logs")
-	// debug for keyvisual
-	// Hide help information
-	flag.Int64Var(&cfg.KVFileStartTime, "keyvis-file-start", 0, "(debug) start time for file range in file mode")
-	flag.Int64Var(&cfg.KVFileEndTime, "keyvis-file-end", 0, "(debug) end time for file range in file mode")
+	// debug for keyvisual，hide help information
+	flag.Int64Var(&cfg.KVFileStartTime, "keyviz-file-start", 0, "(debug) start time for file range in file mode")
+	flag.Int64Var(&cfg.KVFileEndTime, "keyviz-file-end", 0, "(debug) end time for file range in file mode")
 
-	_ = flag.CommandLine.MarkHidden("keyvis-file-start")
-	_ = flag.CommandLine.MarkHidden("keyvis-file-end")
+	_ = flag.CommandLine.MarkHidden("keyviz-file-start")
+	_ = flag.CommandLine.MarkHidden("keyviz-file-end")
 
 	flag.Parse()
 
@@ -98,7 +96,7 @@ func NewCLIConfig() *DashboardCLIConfig {
 	if startTime != 0 || endTime != 0 {
 		// file mode (debug)
 		if startTime == 0 || endTime == 0 || startTime >= endTime {
-			panic("keyvis-file-start must be smaller than keyvis-file-end, and none of them are 0")
+			panic("keyviz-file-start must be smaller than keyviz-file-end, and none of them are 0")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
+	github.com/spf13/pflag v1.0.1
 	github.com/swaggo/http-swagger v0.0.0-20200103000832-0e9263c4b516
 	github.com/swaggo/swag v1.6.5
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738


### PR DESCRIPTION
UCP #138 

## What have you changed? 

Replace the package `flag` with `pflag`
Hide help information for debug parameters, including `keyvis-file-start` and `keyvis-file-end`

## What are the type of the changes? 

New feature 

## How has this PR been tested? (mandatory)

Have run command `make run` successfully

## Does this PR affect documentation (docs/docs-cn) update? 

No
