### PR TITLE
Sql diagnosis: make GetReportTables perform concurrently 

### DIFF
--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -243,15 +243,16 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 	// all task done, close the resChan
 	close(resChan)
 
-	var tblAndErrSlice []tblAndErr
+	tblAndErrSlice := make([]tblAndErr, 0, cap(resChan))
 	for tblAndErr := range resChan {
 		tblAndErrSlice = append(tblAndErrSlice, *tblAndErr)
 	}
 	sort.Slice(tblAndErrSlice, func(i, j int) bool {
 		return tblAndErrSlice[i].taskID < tblAndErrSlice[j].taskID
 	})
-	var tables []*TableDef
-	var errRows []TableRowDef
+
+	tables := make([]*TableDef, 0, len(tblAndErrSlice) + 1)
+	errRows := make([]TableRowDef, 0, len(tblAndErrSlice))
 	for _,v := range tblAndErrSlice {
 		if v.tbl != nil {
 			tables = append(tables, v.tbl)

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -251,9 +251,9 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 		return tblAndErrSlice[i].taskID < tblAndErrSlice[j].taskID
 	})
 
-	tables := make([]*TableDef, 0, len(tblAndErrSlice) + 1)
+	tables := make([]*TableDef, 0, len(tblAndErrSlice)+1)
 	errRows := make([]TableRowDef, 0, len(tblAndErrSlice))
-	for _,v := range tblAndErrSlice {
+	for _, v := range tblAndErrSlice {
 		if v.tbl != nil {
 			tables = append(tables, v.tbl)
 		}

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -242,7 +242,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 	close(resChan)
 	m := make(map[int]*tblAndErr)
 	for tblAndErr := range resChan {
-		m[tblAndErr.taskId] = tblAndErr
+		m[tblAndErr.taskID] = tblAndErr
 	}
 
 	tables := make([]*TableDef, len(funcs))
@@ -260,7 +260,7 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 type tblAndErr struct {
 	tbl    *TableDef
 	err    *TableRowDef
-	taskId int
+	taskID int
 }
 
 // 1.doGetTable gets the task from taskChan,and close the taskChan if taskChan is empty.
@@ -283,9 +283,9 @@ func doGetTable(taskChan chan *task, resChan chan *tblAndErr, doneChan chan bool
 		if tbl != nil {
 			tblAndErr.tbl = tbl
 		}
-		tblAndErr.taskId = task.taskId
+		tblAndErr.taskID = task.taskID
 		resChan <- &tblAndErr
-		if tblAndErr.taskId == cap(taskChan)-1 {
+		if tblAndErr.taskID == cap(taskChan)-1 {
 			close(taskChan)
 		}
 	}
@@ -295,7 +295,7 @@ func doGetTable(taskChan chan *task, resChan chan *tblAndErr, doneChan chan bool
 
 type task struct {
 	t      getTableFunc
-	taskId int // taskId for arrange the tables in order
+	taskID int // taskID for arrange the tables in order
 }
 
 //change the get-Table-func to task

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -222,6 +222,9 @@ func GetReportTables(startTime, endTime string, db *gorm.DB) []*TableDef {
 
 	// get the local CPU count for concurrence
 	conc := runtime.NumCPU()
+	if conc > 8 {
+		conc = 8
+	}
 	taskChan := func2task(funcs)
 	resChan := make(chan *tblAndErr, len(funcs))
 	doneChan := make(chan bool, conc)

--- a/pkg/apiserver/diagnose/report_test.go
+++ b/pkg/apiserver/diagnose/report_test.go
@@ -32,7 +32,7 @@ var _ = Suite(&testReportSuite{})
 type testReportSuite struct{}
 
 func (t *testReportSuite) TestReport(c *C) {
-	cli, err := gorm.Open("mysql", "root:@tcp(127.0.0.1:4000)/test?charset=utf8&parseTime=True&loc=Local")
+	cli, err := gorm.Open("mysql", "root:@tcp(172.16.5.40:4009)/test?charset=utf8&parseTime=True&loc=Local")
 	c.Assert(err, IsNil)
 	defer cli.Close()
 


### PR DESCRIPTION
cluster：
![image](https://user-images.githubusercontent.com/30926443/75879658-b4b23e00-5e56-11ea-9f3c-1e147e534d7c.png)

before：
![image](https://user-images.githubusercontent.com/30926443/75878635-de6a6580-5e54-11ea-8e53-82803a158c79.png)

this pr：
2 cores：
![image](https://user-images.githubusercontent.com/30926443/75879073-ab74a180-5e55-11ea-8c6b-cb69b809ea19.png)

4 cores：
![image](https://user-images.githubusercontent.com/30926443/75878598-d0b4e000-5e54-11ea-88d2-10c2600b04f3.png)

6 cores：
![image](https://user-images.githubusercontent.com/30926443/75879156-d959e600-5e55-11ea-8ffa-6272ac1cad6e.png)

8 cores：
![image](https://user-images.githubusercontent.com/30926443/75878972-749e8b80-5e55-11ea-9b00-98b3241c4eba.png)

15 cores：
![image](https://user-images.githubusercontent.com/30926443/75879542-86ccf980-5e56-11ea-917a-29146dddb233.png)

We can see that over 6 cores it would not get better performance. It due to some siggle table cost too much time that makes the whole time equal it’s time. So I set the cores not beyond 8 cores.