### PR TITLE
build: upgrade golangci-lint from 1.23.3 to 1.23.8

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,7 @@ PROJECT_DIR="$(dirname "$DIR")"
 cd $PROJECT_DIR
 
 LINT_BIN=./bin/golangci-lint
-REQUIRED_VERSION=1.23.3
+REQUIRED_VERSION=1.23.8
 NEED_DOWNLOAD=true
 
 echo "+ Check golangci-lint binary"


### PR DESCRIPTION
because golangci-lint 1.23.3 does NOT play well with go 1.14

**Related issue** 

https://github.com/pingcap-incubator/tidb-dashboard/issues/172