### PR TITLE
service: cancel the internal context when stopped

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -56,26 +56,14 @@ type Service struct {
 	app    *fx.App
 	status *utils2.ServiceStatus
 
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	config            *config.Config
 	newPDDataProvider PDDataProviderConstructor
 	stoppedHandler    http.Handler
 
 	apiHandlerEngine *gin.Engine
-}
-
-func newAPIHandlerEngine() (apiHandlerEngine *gin.Engine, endpoint *gin.RouterGroup, newTemplate utils2.NewTemplateFunc) {
-	apiHandlerEngine = gin.New()
-	apiHandlerEngine.Use(cors.AllowAll())
-	apiHandlerEngine.Use(gzip.Gzip(gzip.BestSpeed))
-	apiHandlerEngine.Use(utils.MWHandleErrors())
-
-	endpoint = apiHandlerEngine.Group("/dashboard/api")
-
-	newTemplate = func(name string) *template.Template {
-		return template.New(name).Funcs(apiHandlerEngine.FuncMap)
-	}
-
-	return
 }
 
 func NewService(cfg *config.Config, stoppedHandler http.Handler, newPDDataProvider PDDataProviderConstructor) *Service {
@@ -100,6 +88,7 @@ func Register(r *gin.RouterGroup, s *Service) {
 }
 
 func (s *Service) Start(ctx context.Context) error {
+	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.app = fx.New(
 		fx.Logger(utils2.NewFxPrinter()),
 		fx.Provide(
@@ -140,15 +129,22 @@ func (s *Service) Start(ctx context.Context) error {
 	if err := s.app.Err(); err != nil {
 		return err
 	}
-	if err := s.app.Start(ctx); err != nil {
+	if err := s.app.Start(s.ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (s *Service) Stop(ctx context.Context) error {
+	s.cancel()
 	err := s.app.Stop(ctx)
+
+	// drop
+	s.app = nil
 	s.apiHandlerEngine = nil
+	s.ctx = nil
+	s.cancel = nil
+
 	return err
 }
 
@@ -162,6 +158,21 @@ func (s *Service) handler(c *gin.Context) {
 
 func (s *Service) provideLocals() *config.Config {
 	return s.config
+}
+
+func newAPIHandlerEngine() (apiHandlerEngine *gin.Engine, endpoint *gin.RouterGroup, newTemplate utils2.NewTemplateFunc) {
+	apiHandlerEngine = gin.New()
+	apiHandlerEngine.Use(cors.AllowAll())
+	apiHandlerEngine.Use(gzip.Gzip(gzip.BestSpeed))
+	apiHandlerEngine.Use(utils.MWHandleErrors())
+
+	endpoint = apiHandlerEngine.Group("/dashboard/api")
+
+	newTemplate = func(name string) *template.Template {
+		return template.New(name).Funcs(apiHandlerEngine.FuncMap)
+	}
+
+	return
 }
 
 var StoppedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -131,9 +131,16 @@ func (s *Service) Start(ctx context.Context) error {
 }
 
 func (s *Service) Stop(ctx context.Context) error {
+	s.cancel()
 	err := s.app.Stop(ctx)
+
+	// drop
+	s.app = nil
 	s.stat = nil
 	s.strategy = nil
+	s.ctx = nil
+	s.cancel = nil
+
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

The `Service.Stop` function has been blocked because `ctx` was not canceled.
This PR fixes this issue.