### PR TITLE
keyvis: support to display DB Name

### DIFF
--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -106,8 +106,7 @@ func (s *tidbLabelStrategy) Label(key string) (label LabelKey) {
 		label.Labels = append(label.Labels, "meta")
 	} else if v, ok := s.TableMap.Load(TableID); ok {
 		detail := v.(*tableDetail)
-		label.Labels = append(label.Labels, detail.DB)
-		label.Labels = append(label.Labels, detail.Name)
+		label.Labels = append(label.Labels, detail.DB, detail.Name)
 		if rowID := decodeKey.RowID(); rowID != 0 {
 			label.Labels = append(label.Labels, fmt.Sprintf("row_%d", rowID))
 		} else if indexID := decodeKey.IndexID(); indexID != 0 {

--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -106,6 +106,7 @@ func (s *tidbLabelStrategy) Label(key string) (label LabelKey) {
 		label.Labels = append(label.Labels, "meta")
 	} else if v, ok := s.TableMap.Load(TableID); ok {
 		detail := v.(*tableDetail)
+		label.Labels = append(label.Labels, detail.DB)
 		label.Labels = append(label.Labels, detail.Name)
 		if rowID := decodeKey.RowID(); rowID != 0 {
 			label.Labels = append(label.Labels, fmt.Sprintf("row_%d", rowID))

--- a/ui/packages/keyvis/src/heatmap/chart.ts
+++ b/ui/packages/keyvis/src/heatmap/chart.ts
@@ -13,7 +13,7 @@ const margin = {
   top: 25,
   right: 40,
   bottom: 70,
-  left: 70,
+  left: 100,
 }
 
 const tooltipOffset = {
@@ -182,9 +182,9 @@ export async function heatmapChart(
       .style('position', 'absolute')
       .style('z-index', '102')
       .merge(labelCanvas)
-      .style('width', 60 + 'px')
+      .style('width', 90 + 'px')
       .style('height', canvasHeight + 'px')
-      .attr('width', 60 * window.devicePixelRatio)
+      .attr('width', 90 * window.devicePixelRatio)
       .attr('height', canvasHeight * window.devicePixelRatio)
       .style('margin-top', margin.top + 'px')
     labelCanvas

--- a/ui/packages/keyvis/src/heatmap/chart.ts
+++ b/ui/packages/keyvis/src/heatmap/chart.ts
@@ -601,7 +601,7 @@ export async function heatmapChart(
       }
       // range
       if (
-        startLen >= 2 &&
+        startLen >= 3 &&
         startLen == endLen &&
         _.isEqual(
           startLabel.slice(0, startLen - 1),


### PR DESCRIPTION
UCP #247 

## What have you changed? 

Add DB Name in the function `Label` of decorator
Change some parameters in ui/packages/keyvis/src/heatmap/chart.ts

## What are the type of the changes? 

Improvement

## How has this PR been tested? 

Run the following commands in order：
`make ui`
`UI=1 SWAGGER=1 make server`
`make run`
As a result, open the front end and display `DB Name` correctly

## Does this PR affect documentation (docs/docs-cn) update? 

No
