### PR TITLE
Add Tidb Endpoint

### DIFF
--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	EnvTidbOverrideEndpointKey = "TIDB_OVERRIDE_ENDPOINT"
+	envTidbOverrideEndpointKey = "TIDB_OVERRIDE_ENDPOINT"
 )
 
 func (f *Forwarder) GetDBConnProps() (host string, port int, err error) {
@@ -45,7 +45,7 @@ func (f *Forwarder) GetDBConnProps() (host string, port int, err error) {
 
 func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	var addr string
-	addr = os.Getenv(EnvTidbOverrideEndpointKey)
+	addr = os.Getenv(envTidbOverrideEndpointKey)
 	if len(addr) < 1 {
 		host, port, err := f.GetDBConnProps()
 		if err != nil {

--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -34,7 +34,7 @@ const (
 	envTidbOverrideEndpointKey = "TIDB_OVERRIDE_ENDPOINT"
 )
 
-func (f *Forwarder) GetDBConnProps() (host string, port int, err error) {
+func (f *Forwarder) getDBConnProps() (host string, port int, err error) {
 	info, err := f.getServerInfo()
 	if err == nil {
 		host = info.IP
@@ -47,7 +47,7 @@ func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	var addr string
 	addr = os.Getenv(envTidbOverrideEndpointKey)
 	if len(addr) < 1 {
-		host, port, err := f.GetDBConnProps()
+		host, port, err := f.getDBConnProps()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -17,6 +17,8 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -26,6 +28,10 @@ import (
 
 	// MySQL driver used by gorm
 	_ "github.com/jinzhu/gorm/dialects/mysql"
+)
+
+const (
+	EnvTidbOverrideEndpointKey = "TIDB_OVERRIDE_ENDPOINT"
 )
 
 func (f *Forwarder) GetDBConnProps() (host string, port int, err error) {
@@ -38,14 +44,18 @@ func (f *Forwarder) GetDBConnProps() (host string, port int, err error) {
 }
 
 func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
-	host, port, err := f.GetDBConnProps()
-	if err != nil {
-		return nil, err
+	var addr string
+	addr = os.Getenv(EnvTidbOverrideEndpointKey)
+	if len(addr) < 1 {
+		host, port, err := f.GetDBConnProps()
+		if err != nil {
+			return nil, err
+		}
+		addr = fmt.Sprintf("%s:%d", host, port)
 	}
-
 	dsnConfig := mysql.NewConfig()
 	dsnConfig.Net = "tcp"
-	dsnConfig.Addr = fmt.Sprintf("%s:%d", host, port)
+	dsnConfig.Addr = addr
 	dsnConfig.User = user
 	dsnConfig.Passwd = pass
 	dsnConfig.Timeout = time.Second
@@ -57,7 +67,7 @@ func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	db, err := gorm.Open("mysql", dsn)
 	if err != nil {
 		if _, ok := err.(*net.OpError); ok || err == driver.ErrBadConn {
-			if host == "0.0.0.0" {
+			if strings.HasPrefix(addr, "0.0.0.0:") {
 				log.Warn("The IP reported by TiDB is 0.0.0.0, which may not have the -advertise-address option")
 			}
 			return nil, ErrTiDBConnFailed.Wrap(err, "failed to connect to TiDB")


### PR DESCRIPTION
UCP #224

If `TIDB_OVERRIDE_ENDPOINT` ENV is set, the server would read it to connect to the tidb-server. Otherwise it would work as the previous.