### PR TITLE
diagnose: fix metric-storage check

### DIFF
--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -110,55 +110,12 @@ func GetReportTablesForDisplay(startTime, endTime string, db *gorm.DB, sqliteDB 
 }
 
 func checkBeforeReport(db *gorm.DB) (errRows []TableRowDef) {
-	sql := "select count(distinct value) from information_schema.cluster_config where type='pd' and `key` = 'pd-server.metric-storage' and value != '';"
-	rows, err := querySQL(db, sql)
-	if err != nil {
-		errRows = append(errRows, TableRowDef{
-			Values: []string{"check before report", "information_schema.cluster_config", err.Error()},
-		})
-		return
-	}
-	if len(rows) == 0 {
-		errRows = append(errRows, TableRowDef{
-			Values: []string{"check before report", "information_schema.cluster_config", "The PD config `pd-server.metric-storage` was not found"},
-		})
-		return
-	}
-	count, err := strconv.Atoi(rows[0][0])
-	if err != nil {
-		errRows = append(errRows, TableRowDef{
-			Values: []string{"check before report", "information_schema.cluster_config", "check the sql result: " + sql + " ,the expect result is 1"},
-		})
-		return
-	}
 	command := "you can use this shell command to set the config: `curl -X POST -d '{\"metric-storage\":\"http://{PROMETHEUS_ADDRESS}\"}' http://{PD_ADDRESS}/pd/api/v1/config`, \n" +
 		"PROMETHEUS_ADDRESS is the prometheus address, It's used for query metric data; PD_ADDRESS is the HTTP API address of PD server, all PD servers need to set this config. \n" +
 		"Here is an example: `curl -X POST -d '{\"metric-storage\":\"http://127.0.0.1:9090\"}' http://127.0.0.1:2379/pd/api/v1/config`"
-	if count == 0 {
-		errRows = append(errRows, TableRowDef{
-			Values: []string{
-				"check before report",
-				"information_schema.cluster_config",
-				"The PD config `pd-server.metric-storage` was not set, \n" + command,
-			},
-		})
-		return
-	}
-	if count > 1 {
-		errRows = append(errRows, TableRowDef{
-			Values: []string{
-				"check before report",
-				"information_schema.cluster_config",
-				"The PD config `pd-server.metric-storage` value is different from PD servers, \n" +
-					"check the sql result: " + sql + " ,the expect result is 1, \n" + command,
-			},
-		})
-		return
-	}
-
 	// Check for query metric.
-	sql = "select count(*) from metrics_schema.up;"
-	_, err = querySQL(db, sql)
+	sql := "select count(*) from metrics_schema.up;"
+	_, err := querySQL(db, sql)
 	if err != nil {
 		errRows = append(errRows, TableRowDef{
 			Values: []string{


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

Change `metric-storage` check.

After https://github.com/pingcap/tidb/pull/15304, Setting the PD `metric-storage` config value is not necessary anymore.