### PR TITLE
add @ant-design/icons dependency for statement

### DIFF
--- a/ui/packages/statement/package.json
+++ b/ui/packages/statement/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@baurine/grafana-value-formats": "^0.1.1",
     "@pingcap-incubator/dashboard_client": "^0.0.8",
+    "@ant-design/icons": "^4.0.0",
     "antd": "^4.0.0",
     "i18next": "^19.1.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
This make the bundle size reduce from 1.1M back to 39KB.