### PR TITLE
ui: reduce bundle size

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -9,6 +9,7 @@ jobs:
   e2e_test:
     name: UI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@master

--- a/ui/packages/statement/src/components/StatementSummaryTable.tsx
+++ b/ui/packages/statement/src/components/StatementSummaryTable.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import { Table } from 'antd'
 import moment from 'moment'
-import { StatementDetailInfo } from './statement-types'
 import { useTranslation } from 'react-i18next'
-import SyntaxHighlighter from 'react-syntax-highlighter'
-import { atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import sqlFormatter from 'sql-formatter-plus'
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
+import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql'
+import { atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import { StatementDetailInfo } from './statement-types'
+
+SyntaxHighlighter.registerLanguage('sql', sql)
 
 type align = 'left' | 'right' | 'center'
 

--- a/ui/packages/statement/src/components/StatementSummaryTable.tsx
+++ b/ui/packages/statement/src/components/StatementSummaryTable.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import sqlFormatter from 'sql-formatter-plus'
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter'
 import sql from 'react-syntax-highlighter/dist/esm/languages/hljs/sql'
-import { atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import atomOneLight from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light'
 import { StatementDetailInfo } from './statement-types'
 
 SyntaxHighlighter.registerLanguage('sql', sql)


### PR DESCRIPTION
- only import sql syntax highlight instead of importing all languages to reduce bundle size

This can help reduce the highlight.js bundle size from ~900KB to ~30KB.

Ref: https://www.npmjs.com/package/react-syntax-highlighter#light-build
