### PR TITLE
ui:  support customize range duration for diagnosis

### DIFF
--- a/ui/src/apps/diagnose/components/DiagnoseGenerator.tsx
+++ b/ui/src/apps/diagnose/components/DiagnoseGenerator.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Card } from '@pingcap-incubator/dashboard_components'
 import { useHistory } from 'react-router-dom'
 import client from '@pingcap-incubator/dashboard_client'
+import styles from './styles.module.less'
 
 const useFinishHandler = (history) => {
   return async (fieldsValue) => {
@@ -88,7 +89,7 @@ export default function DiagnoseGenerator() {
           <Form.Item name="rangeDuration" noStyle>
             <InputNumber min={1} max={24 * 60} />
           </Form.Item>
-          <div style={{ marginTop: 4, marginLeft: -8 }}>
+          <div className={styles.range_duration_shortcuts}>
             {rangeDurationShortcuts.map((item, idx) => (
               <>
                 <Button

--- a/ui/src/apps/diagnose/components/DiagnoseGenerator.tsx
+++ b/ui/src/apps/diagnose/components/DiagnoseGenerator.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Button, DatePicker, Form, Select, Switch, message } from 'antd'
+import React, { useMemo } from 'react'
+import { Button, DatePicker, Form, Switch, message, InputNumber } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { Card } from '@pingcap-incubator/dashboard_components'
 import { useHistory } from 'react-router-dom'
@@ -36,10 +36,42 @@ export default function DiagnoseGenerator() {
   const { t } = useTranslation()
   const history = useHistory()
   const handleFinish = useFinishHandler(history)
+  const [form] = Form.useForm()
+
+  const rangeDurationShortcuts = useMemo(
+    () => [
+      {
+        val: 5,
+        text: t('diagnose.time_duration.min_with_count', { count: 5 }),
+      },
+      {
+        val: 10,
+        text: t('diagnose.time_duration.min_with_count', { count: 10 }),
+      },
+      {
+        val: 30,
+        text: t('diagnose.time_duration.min_with_count', { count: 30 }),
+      },
+      {
+        val: 60,
+        text: t('diagnose.time_duration.hour_with_count', { count: 1 }),
+      },
+      {
+        val: 24 * 60,
+        text: t('diagnose.time_duration.day_with_count', { count: 1 }),
+      },
+    ],
+    [t]
+  )
+
+  function changeRangeDuration(val: number) {
+    form.setFieldsValue({ rangeDuration: val })
+  }
 
   return (
     <Card title={t('diagnose.generate.title')}>
       <Form
+        form={form}
         layout="vertical"
         style={{ minWidth: 500 }}
         onFinish={handleFinish}
@@ -52,18 +84,25 @@ export default function DiagnoseGenerator() {
         >
           <DatePicker showTime />
         </Form.Item>
-        <Form.Item
-          name="rangeDuration"
-          rules={[{ required: true }]}
-          label={t('diagnose.generate.range_duration')}
-        >
-          <Select style={{ width: 120 }}>
-            <Select.Option value={5}>5 min</Select.Option>
-            <Select.Option value={10}>10 min</Select.Option>
-            <Select.Option value={30}>30 min</Select.Option>
-            <Select.Option value={60}>1 hour</Select.Option>
-            <Select.Option value={24 * 60}>1 day</Select.Option>
-          </Select>
+        <Form.Item required label={t('diagnose.generate.range_duration')}>
+          <Form.Item name="rangeDuration" noStyle>
+            <InputNumber min={1} max={24 * 60} />
+          </Form.Item>
+          <div style={{ marginTop: 4, marginLeft: -8 }}>
+            {rangeDurationShortcuts.map((item, idx) => (
+              <>
+                <Button
+                  type="link"
+                  size="small"
+                  key={item.val}
+                  onClick={() => changeRangeDuration(item.val)}
+                >
+                  {item.text}
+                </Button>
+                {idx < rangeDurationShortcuts.length - 1 && '/'}
+              </>
+            ))}
+          </div>
         </Form.Item>
         <Form.Item
           name="isCompare"

--- a/ui/src/apps/diagnose/components/styles.module.less
+++ b/ui/src/apps/diagnose/components/styles.module.less
@@ -1,0 +1,10 @@
+.range_duration_shortcuts {
+  margin-top: 4px;
+  margin-left: -8px;
+  color: grey;
+  font-size: 12px;
+
+  :global(.ant-btn) {
+    color: grey;
+  }
+}

--- a/ui/src/apps/diagnose/translations/en.yaml
+++ b/ui/src/apps/diagnose/translations/en.yaml
@@ -3,7 +3,7 @@ diagnose:
   generate:
     title: New Diagnose Report
     range_begin: Diagnose Begin Range
-    range_duration: Range Size (min)
+    range_duration: Range Duration (min)
     is_compare: Compare by Baseline
     compare_range_begin: Baseline Begin Range
     submit: Generate

--- a/ui/src/apps/diagnose/translations/en.yaml
+++ b/ui/src/apps/diagnose/translations/en.yaml
@@ -3,7 +3,7 @@ diagnose:
   generate:
     title: New Diagnose Report
     range_begin: Diagnose Begin Range
-    range_duration: Range Size
+    range_duration: Range Size (min)
     is_compare: Compare by Baseline
     compare_range_begin: Baseline Begin Range
     submit: Generate
@@ -16,3 +16,10 @@ diagnose:
     range_end: Range End Time
     baseline_begin: Baseline Range Start Time
     progress: Progress
+  time_duration:
+    min: min
+    min_with_count: '{{count}} min'
+    min_with_count_plural: '{{count}} mins'
+    hour_with_count: '{{count}} hour'
+    hour_with_count_plural: '{{count}} hours'
+    day_with_count: '{{count}} day'

--- a/ui/src/apps/diagnose/translations/zh-CN.yaml
+++ b/ui/src/apps/diagnose/translations/zh-CN.yaml
@@ -3,7 +3,7 @@ diagnose:
   generate:
     title: 生成诊断报告
     range_begin: 诊断区间起始时间
-    range_duration: 区间大小 (分钟)
+    range_duration: 区间时长 (分钟)
     is_compare: 与其他区间对比
     compare_range_begin: 基线区间起始时间
     submit: 生成报告

--- a/ui/src/apps/diagnose/translations/zh-CN.yaml
+++ b/ui/src/apps/diagnose/translations/zh-CN.yaml
@@ -3,7 +3,7 @@ diagnose:
   generate:
     title: 生成诊断报告
     range_begin: 诊断区间起始时间
-    range_duration: 区间大小
+    range_duration: 区间大小 (分钟)
     is_compare: 与其他区间对比
     compare_range_begin: 基线区间起始时间
     submit: 生成报告
@@ -16,3 +16,10 @@ diagnose:
     range_end: 区间结束时间
     baseline_begin: 基线区间起始时间
     progress: 生成进度
+  time_duration:
+    min: 分钟
+    min_with_count: '{{count}} 分钟'
+    min_with_count_plural: '{{count}} 分钟'
+    hour_with_count: '{{count}} 小时'
+    hour_with_count_plural: '{{count}} 小时'
+    day_with_count: '{{count}} 天'


### PR DESCRIPTION
- support to customize the range duration for generating diagnosis report

screenshots:

![image](https://user-images.githubusercontent.com/1284531/77742741-e97a7500-7051-11ea-9ba8-9ffbbc24ea9d.png)
