### PR TITLE
feat(diagnose): add a sample left navigator for diagnose report

### DIFF
--- a/pkg/apiserver/diagnose/templates/index.gohtml
+++ b/pkg/apiserver/diagnose/templates/index.gohtml
@@ -23,10 +23,28 @@
                 display: inline-block;
                 width: 60px;
             }
+
+            .sidenav {
+                height: 100%;
+                width: 250px;
+                position: fixed;
+                z-index: 1;
+                top: 0;
+                left: 0;
+                padding-top: 60px;
+            }
+
+            .sidenav a {
+                padding: 8px 8px 8px 32px;
+                text-decoration: none;
+                display: block;
+            }
+
         </style>
     </head>
     <body>
     <section class="section">
+        {{ template "sql-diagnosis/navigator" . }}
         <div class="container">
             <h1 class="title is-size-1">TiDB SQL Diagnosis System Report</h1>
             <div>

--- a/pkg/apiserver/diagnose/templates/index.gohtml
+++ b/pkg/apiserver/diagnose/templates/index.gohtml
@@ -32,6 +32,7 @@
                 top: 0;
                 left: 0;
                 padding-top: 60px;
+                overflow: scroll;
             }
 
             .sidenav a {

--- a/pkg/apiserver/diagnose/templates/navigator.gohtml
+++ b/pkg/apiserver/diagnose/templates/navigator.gohtml
@@ -1,0 +1,9 @@
+{{ define "sql-diagnosis/navigator" }}
+    <div class="navigator-container">
+        <div class="sidenav">
+            {{ range . }}
+                <a href="#{{.Title}}"> {{index .Category 0}} {{ .Title }}</a>
+            {{ end }}
+        </div>
+    </div>
+{{ end }}

--- a/pkg/apiserver/diagnose/templates/table.gohtml
+++ b/pkg/apiserver/diagnose/templates/table.gohtml
@@ -19,7 +19,7 @@
                 {{ end }}
             {{ end }}
         {{ end }}
-        <h3 class="is-size-4">{{ .Title }}</h3>
+        <h3 id="{{ .Title }}" class="is-size-4">{{ .Title }}</h3>
         {{ if .CommentEN }}
             <p>{{ .CommentEN }}</p>
         {{ end }}


### PR DESCRIPTION
UCP #200

# What have you changed?

Add a left navigator for diagnose report.

- Add a `id` property for `h3` HTML tag as anchor. It takes value from `TableDef.Title`.
- Add a new template file `navigator.gohtml`.
- Some CSS in `index.gohtml`

# What are the type of the changes?

New feature.

# How has this PR been tested?

Manually tested.

Preview:

![Preview](https://i.imgur.com/5ioSBG9.png)

HTML file: https://paste.ubuntu.com/p/ksXCmTjHgr/


# Does this PR affect documentation (docs/docs-cn) update?
No.

# Refer to a related PR or issue link
#200