### PR TITLE
Use /statement instead of /statement/overview

### DIFF
--- a/ui/packages/statement/src/RootComponent.tsx
+++ b/ui/packages/statement/src/RootComponent.tsx
@@ -23,7 +23,6 @@ const App = () => {
     curTimeRange: undefined,
   } as SearchOptions)
   const searchContext = { searchOptions, setSearchOptions }
-
   return (
     <SearchContext.Provider value={searchContext}>
       <div>


### PR DESCRIPTION
After https://github.com/pingcap-incubator/tidb-dashboard/pull/301, entering `/statement` will be redirected to `/statement/overview` after mounted but this does not affect the later routing to `/statement`. This PR fixes this behavior.

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>