### PR TITLE
cluster_info: fix empty start_timestamp in cluster info page

### DIFF
--- a/ui/src/apps/clusterInfo/pages/List.js
+++ b/ui/src/apps/clusterInfo/pages/List.js
@@ -182,7 +182,7 @@ export default function ListPage() {
       dataIndex: 'start_timestamp',
       width: 150,
       render: (ts) => {
-        if (ts !== undefined) {
+        if (ts !== undefined && ts !== 0) {
           return <DateTime.Calendar unixTimeStampMs={ts * 1000} />
         }
       },


### PR DESCRIPTION
Preview:
![image](https://user-images.githubusercontent.com/9463871/78870593-f72ff180-7a78-11ea-91f3-828e6b5eff55.png)

