### PR TITLE
Add navigation menu for diagnosis reports

### DIFF
--- a/ui/diagnoseReportApp/components/DiagnosisReport.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisReport.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import DiagnosisTable from './DiagnosisTable'
-import { ExpandContext } from '../types'
+import { ExpandContext, TableDef } from '../types'
 import { ALL_LANGUAGES } from '@lib/utils/i18n'
 
 function LangDropdown() {
@@ -22,8 +22,11 @@ function LangDropdown() {
   )
 }
 
-export default function DiagnosisReport() {
-  const diagnosisData = window['__diagnosis_data__'] || []
+type Props = {
+  diagnosisTables: TableDef[]
+}
+
+export default function DiagnosisReport({ diagnosisTables }: Props) {
   const [expandAll, setExpandAll] = useState(false)
   const { t } = useTranslation()
 
@@ -31,7 +34,7 @@ export default function DiagnosisReport() {
     <section className="section">
       <div className="container">
         <h1 className="title is-size-1">{t('diagnosis.title')}</h1>
-        <div>
+        <div className="actions sticky-top">
           <LangDropdown />
           <button
             className="button is-link is-light"
@@ -46,10 +49,41 @@ export default function DiagnosisReport() {
           >
             {t('diagnosis.fold_all')}
           </button>
+          <div className="dropdown is-hoverable">
+            <div className="dropdown-trigger">
+              <a className="navbar-link">Tables</a>
+            </div>
+            <div className="dropdown-menu">
+              <div
+                className="dropdown-content"
+                style={{
+                  maxHeight: 500,
+                  overflowY: 'scroll',
+                }}
+              >
+                {diagnosisTables.map((item) => (
+                  <>
+                    <h2 style={{ paddingLeft: 16 }}>
+                      {item.Category[0] &&
+                        t(`diagnosis.tables.category.${item.Category[0]}`)}
+                    </h2>
+                    <a
+                      style={{ paddingLeft: 28 }}
+                      key={item.Title}
+                      href={`#${item.Title}`}
+                      className="dropdown-item"
+                    >
+                      {t(`diagnosis.tables.title.${item.Title}`)}
+                    </a>
+                  </>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
 
         <ExpandContext.Provider value={expandAll}>
-          {diagnosisData.map((item, idx) => (
+          {diagnosisTables.map((item, idx) => (
             <DiagnosisTable diagnosis={item} key={idx} />
           ))}
         </ExpandContext.Provider>

--- a/ui/diagnoseReportApp/components/DiagnosisReport.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisReport.tsx
@@ -51,7 +51,7 @@ export default function DiagnosisReport({ diagnosisTables }: Props) {
           </button>
           <div className="dropdown is-hoverable">
             <div className="dropdown-trigger">
-              <a className="navbar-link">Tables</a>
+              <a className="navbar-link">{t('diagnosis.all_tables')}</a>
             </div>
             <div className="dropdown-menu">
               <div

--- a/ui/diagnoseReportApp/components/DiagnosisReport.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisReport.tsx
@@ -34,7 +34,7 @@ export default function DiagnosisReport({ diagnosisTables }: Props) {
     <section className="section">
       <div className="container">
         <h1 className="title is-size-1">{t('diagnosis.title')}</h1>
-        <div className="actions sticky-top">
+        <div className="actions">
           <LangDropdown />
           <button
             className="button is-link is-light"

--- a/ui/diagnoseReportApp/components/DiagnosisReport.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisReport.tsx
@@ -26,6 +26,42 @@ type Props = {
   diagnosisTables: TableDef[]
 }
 
+function TablesNavMenu({ diagnosisTables }: Props) {
+  const { t } = useTranslation()
+  return (
+    <div className="dropdown is-hoverable">
+      <div className="dropdown-trigger">
+        <a className="navbar-link">{t('diagnosis.all_tables')}</a>
+      </div>
+      <div className="dropdown-menu">
+        <div
+          className="dropdown-content"
+          style={{
+            maxHeight: 500,
+            overflowY: 'scroll',
+          }}
+        >
+          {diagnosisTables.map((item) => (
+            <React.Fragment key={item.Title}>
+              <h2 style={{ paddingLeft: 16 }}>
+                {item.Category[0] &&
+                  t(`diagnosis.tables.category.${item.Category[0]}`)}
+              </h2>
+              <a
+                style={{ paddingLeft: 32 }}
+                className="dropdown-item"
+                href={`#${item.Title}`}
+              >
+                {t(`diagnosis.tables.title.${item.Title}`)}
+              </a>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function DiagnosisReport({ diagnosisTables }: Props) {
   const [expandAll, setExpandAll] = useState(false)
   const { t } = useTranslation()
@@ -49,37 +85,7 @@ export default function DiagnosisReport({ diagnosisTables }: Props) {
           >
             {t('diagnosis.fold_all')}
           </button>
-          <div className="dropdown is-hoverable">
-            <div className="dropdown-trigger">
-              <a className="navbar-link">{t('diagnosis.all_tables')}</a>
-            </div>
-            <div className="dropdown-menu">
-              <div
-                className="dropdown-content"
-                style={{
-                  maxHeight: 500,
-                  overflowY: 'scroll',
-                }}
-              >
-                {diagnosisTables.map((item) => (
-                  <>
-                    <h2 style={{ paddingLeft: 16 }}>
-                      {item.Category[0] &&
-                        t(`diagnosis.tables.category.${item.Category[0]}`)}
-                    </h2>
-                    <a
-                      style={{ paddingLeft: 28 }}
-                      key={item.Title}
-                      href={`#${item.Title}`}
-                      className="dropdown-item"
-                    >
-                      {t(`diagnosis.tables.title.${item.Title}`)}
-                    </a>
-                  </>
-                ))}
-              </div>
-            </div>
-          </div>
+          <TablesNavMenu diagnosisTables={diagnosisTables} />
         </div>
 
         <ExpandContext.Provider value={expandAll}>

--- a/ui/diagnoseReportApp/components/DiagnosisTable.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisTable.tsx
@@ -82,11 +82,24 @@ export default function DiagnosisTable({ diagnosis }: Props) {
       ))}
       <h3 className="is-size-4">{t(`diagnosis.tables.title.${Title}`)}</h3>
       {Comment && <p>{t(`diagnosis.tables.comment.${Comment}`)}</p>}
-      <table className="table is-bordered is-hoverable is-narrow is-fullwidth">
+      <table
+        className="table is-bordered is-hoverable is-narrow is-fullwidth"
+        style={{ position: 'relative' }}
+      >
         <thead>
           <tr>
             {Column.map((col, colIdx) => (
-              <th key={colIdx}>{col}</th>
+              <th
+                style={{
+                  position: 'sticky',
+                  top: 55,
+                  backgroundColor: 'white',
+                  zIndex: 1,
+                }}
+                key={colIdx}
+              >
+                {col}
+              </th>
             ))}
           </tr>
         </thead>

--- a/ui/diagnoseReportApp/components/DiagnosisTable.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisTable.tsx
@@ -89,15 +89,7 @@ export default function DiagnosisTable({ diagnosis }: Props) {
         <thead>
           <tr>
             {Column.map((col, colIdx) => (
-              <th
-                style={{
-                  position: 'sticky',
-                  top: 55,
-                  backgroundColor: 'white',
-                  zIndex: 1,
-                }}
-                key={colIdx}
-              >
+              <th className="table-header-row" key={colIdx}>
                 {col}
               </th>
             ))}

--- a/ui/diagnoseReportApp/components/DiagnosisTable.tsx
+++ b/ui/diagnoseReportApp/components/DiagnosisTable.tsx
@@ -74,7 +74,7 @@ export default function DiagnosisTable({ diagnosis }: Props) {
   const { t } = useTranslation()
 
   return (
-    <div className="report-container">
+    <div className="report-container" id={Title}>
       {(Category || []).map((c, idx) => (
         <h1 className={`title is-size-${idx + 2}`} key={idx}>
           {c && t(`diagnosis.tables.category.${c}`)}

--- a/ui/diagnoseReportApp/index.css
+++ b/ui/diagnoseReportApp/index.css
@@ -17,13 +17,20 @@ tr.subvalues.fold {
   color: #2160c4;
 }
 
-.sticky-top {
-  position: sticky;
-  top: 0;
-}
-
 .actions {
   padding: 8px 0;
   background-color: white;
+
+  position: sticky;
+  top: 0;
   z-index: 2;
+}
+
+.table-header-row {
+  position: sticky;
+  top: 55px;
+  z-index: 1;
+
+  background-color: #888;
+  color: white !important;
 }

--- a/ui/diagnoseReportApp/index.css
+++ b/ui/diagnoseReportApp/index.css
@@ -25,5 +25,5 @@ tr.subvalues.fold {
 .actions {
   padding: 8px 0;
   background-color: white;
-  z-index: 1;
+  z-index: 2;
 }

--- a/ui/diagnoseReportApp/index.css
+++ b/ui/diagnoseReportApp/index.css
@@ -16,3 +16,14 @@ tr.subvalues.fold {
   cursor: pointer;
   color: #2160c4;
 }
+
+.sticky-top {
+  position: sticky;
+  top: 0;
+}
+
+.actions {
+  padding: 8px 0;
+  background-color: white;
+  z-index: 1;
+}

--- a/ui/diagnoseReportApp/index.js
+++ b/ui/diagnoseReportApp/index.js
@@ -8,8 +8,24 @@ import * as i18n from '@lib/utils/i18n'
 import DiagnosisReport from './components/DiagnosisReport'
 import './index.css'
 
-console.log(window.__diagnosis_data__)
+function refineDiagnosisData() {
+  const diagnosisData = window.__diagnosis_data__ || []
+  console.log(window.__diagnosis_data__)
+
+  let preCategory = ''
+  diagnosisData.forEach((d) => {
+    if (d.Category.join('') === preCategory) {
+      d.Category = []
+    } else {
+      preCategory = d.Category.join('')
+    }
+  })
+  return diagnosisData
+}
 
 i18n.addTranslations(require.context('./translations/', false, /\.yaml$/))
 
-ReactDOM.render(<DiagnosisReport />, document.getElementById('root'))
+ReactDOM.render(
+  <DiagnosisReport diagnosisTables={refineDiagnosisData()} />,
+  document.getElementById('root')
+)

--- a/ui/diagnoseReportApp/translations/en.yaml
+++ b/ui/diagnoseReportApp/translations/en.yaml
@@ -4,6 +4,7 @@ diagnosis:
   fold_all: Fold All
   expand: expand
   fold: fold
+  all_tables: All Tables
   tables:
     category:
       header: Header

--- a/ui/diagnoseReportApp/translations/zh-CN.yaml
+++ b/ui/diagnoseReportApp/translations/zh-CN.yaml
@@ -4,6 +4,7 @@ diagnosis:
   fold_all: 收起所有
   expand: 展开
   fold: 收起
+  all_tables: 所有表
   tables:
     category:
       header: 标头

--- a/ui/diagnoseReportApp/types.ts
+++ b/ui/diagnoseReportApp/types.ts
@@ -10,8 +10,7 @@ export interface TableRowDef {
 export interface TableDef {
   Category: string[]
   Title: string
-  CommentEN: string
-  CommentCN: string
+  Comment: string
   joinColumns: number[]
   compareColumns: number[]
   Column: string[]


### PR DESCRIPTION
What did:

- Add navigation menus for all report tables
- Sticky the nav menu
- Sticky the tables  header
- Remove duplicated category

The design is coarse and ugly, can be refined later.

![32](https://user-images.githubusercontent.com/1284531/79680744-c3f21d00-8245-11ea-977d-a93c5327476e.gif)

@crazycs520 
