### PR TITLE
slow_query: improvement slow query page

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -113,6 +113,7 @@ func getAllColumnNames() []string {
 			ret = append(ret, list[1])
 		}
 	}
+	ret = append(ret, "Time")
 	return ret
 }
 
@@ -162,8 +163,8 @@ func QuerySlowLogList(db *gorm.DB, params *QueryRequestParam) ([]Base, error) {
 
 func QuerySlowLogDetail(db *gorm.DB, req *DetailRequest) (*SlowQuery, error) {
 	var result SlowQuery
-	upperBound := req.Time
-	lowerBound := req.Time - 10e-7
+	upperBound := req.Time + 10E-7
+	lowerBound := req.Time - 10E-7
 	err := db.Select(SelectStmt).Table(SlowQueryTable).
 		Where("Digest = ?", req.Digest).
 		Where("Time >= from_unixtime(?) and Time <= from_unixtime(?)", lowerBound, upperBound).

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -129,11 +129,12 @@ func QuerySlowLogList(db *gorm.DB, params *QueryRequestParam) ([]Base, error) {
 	tx := db.Select(SelectStmt).Table(SlowQueryTable)
 	tx = tx.Where("time between from_unixtime(?) and from_unixtime(?)", params.LogStartTS, params.LogEndTS)
 	if params.Text != "" {
-		tx = tx.Where("txn_start_ts REGEXP ? OR digest REGEXP ? OR prev_stmt REGEXP ? OR query REGEXP ?",
-			params.Text,
-			params.Text,
-			params.Text,
-			params.Text,
+		lowerStr := strings.ToLower(params.Text)
+		tx = tx.Where("txn_start_ts REGEXP ? OR LOWER(digest) REGEXP ? OR LOWER(prev_stmt) REGEXP ? OR LOWER(query) REGEXP ?",
+			lowerStr,
+			lowerStr,
+			lowerStr,
+			lowerStr,
 		)
 	}
 

--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -67,7 +67,6 @@ func (s *Service) listHandler(c *gin.Context) {
 	}
 
 	db := utils.GetTiDBConnection(c)
-	db.LogMode(true)
 	results, err := QuerySlowLogList(db, &req)
 	if err != nil {
 		_ = c.Error(err)
@@ -99,7 +98,6 @@ func (s *Service) detailhandler(c *gin.Context) {
 	}
 
 	db := utils.GetTiDBConnection(c)
-	db.LogMode(true)
 	result, err := QuerySlowLogDetail(db, &req)
 	if err != nil {
 		_ = c.Error(err)

--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -61,12 +61,13 @@ func (s *Service) listHandler(c *gin.Context) {
 
 	if req.LogStartTS == 0 {
 		now := time.Now().Unix()
-		before := time.Now().AddDate(0, 0, -1).Unix()
+		before := time.Now().Add(-30 * time.Minute).Unix()
 		req.LogStartTS = before
 		req.LogEndTS = now
 	}
 
 	db := utils.GetTiDBConnection(c)
+	db.LogMode(true)
 	results, err := QuerySlowLogList(db, &req)
 	if err != nil {
 		_ = c.Error(err)
@@ -98,6 +99,7 @@ func (s *Service) detailhandler(c *gin.Context) {
 	}
 
 	db := utils.GetTiDBConnection(c)
+	db.LogMode(true)
 	result, err := QuerySlowLogDetail(db, &req)
 	if err != nil {
 		_ = c.Error(err)

--- a/ui/lib/apps/SlowQuery/components/Detail.tsx
+++ b/ui/lib/apps/SlowQuery/components/Detail.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, Link } from 'react-router-dom'
+import { useLocation, Link, useNavigate } from 'react-router-dom'
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { useClientRequest } from '@lib/utils/useClientRequest'
 import { parseQueryFn, buildQueryFn } from '@lib/utils/query'
 import client from '@lib/client'
-import { Skeleton, Space, Alert } from 'antd'
+import { Skeleton, Space, Alert, Button } from 'antd'
 import {
   Head,
   Descriptions,
@@ -31,6 +31,7 @@ export interface IPageQuery {
 
 function DetailPage() {
   const query = DetailPage.parseQuery(useLocation().search)
+  const navigate = useNavigate()
 
   const { t } = useTranslation()
 
@@ -53,9 +54,14 @@ function DetailPage() {
       <Head
         title={t('slow_query.detail.head.title')}
         back={
-          <Link to={`/slow_query?from=detail`}>
+          <Button
+            type="link"
+            onClick={() => {
+              navigate(-1)
+            }}
+          >
             <ArrowLeftOutlined /> {t('slow_query.detail.head.back')}
-          </Link>
+          </Button>
         }
       >
         {isLoading && <Skeleton active />}

--- a/ui/lib/apps/SlowQuery/components/Detail.tsx
+++ b/ui/lib/apps/SlowQuery/components/Detail.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation, Link, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { useClientRequest } from '@lib/utils/useClientRequest'
 import { parseQueryFn, buildQueryFn } from '@lib/utils/query'

--- a/ui/lib/apps/SlowQuery/components/List.tsx
+++ b/ui/lib/apps/SlowQuery/components/List.tsx
@@ -101,9 +101,7 @@ function List() {
           searchText
         )
       setLoading(false)
-      if (res?.data) {
-        setSlowQueryList(res.data || [])
-      }
+      setSlowQueryList(res.data || [])
     }
     getSlowQueryList()
     const qs = List.buildQuery({
@@ -115,7 +113,16 @@ function List() {
       limit,
     })
     navigate(`/slow_query?${qs}`)
-  }, [curTimeRange, curSchemas, orderBy, desc, searchText, limit, refreshTimes])
+  }, [
+    curTimeRange,
+    curSchemas,
+    orderBy,
+    desc,
+    searchText,
+    limit,
+    refreshTimes,
+    navigate,
+  ])
 
   function handleTimeRangeChange(val: TimeRange) {
     setCurTimeRange(val)

--- a/ui/lib/apps/SlowQuery/components/List.tsx
+++ b/ui/lib/apps/SlowQuery/components/List.tsx
@@ -22,7 +22,7 @@ function tableColumns(
   rows: SlowqueryBase[],
   onColumnClick: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void,
   orderBy: string,
-  desc: boolean,
+  desc: boolean
 ): IColumn[] {
   return [
     useSlowQueryColumn.useSqlColumn(rows),
@@ -67,11 +67,6 @@ export default function List() {
   const [columns, setColumns] = useState<IColumn[]>(
     tableColumns(slowQueryList || [], onColumnClick, orderBy, desc)
   )
-
-  // useEffect(() => {
-  //   setColumns(tableColumns(slowQueryList || [], onColumnClick, orderBy, desc))
-  //   // eslint-disable-next-line
-  // }, [orderBy, desc])
 
   useEffect(() => {
     async function getSchemas() {
@@ -183,9 +178,7 @@ export default function List() {
                 </Option>
               ))}
             </Select>
-            <Search
-              onSearch={handleSearch}
-            />
+            <Search onSearch={handleSearch} />
             <Select
               defaultValue="100"
               style={{ width: 150 }}

--- a/ui/lib/apps/SlowQuery/components/TimeRangeSelector.tsx
+++ b/ui/lib/apps/SlowQuery/components/TimeRangeSelector.tsx
@@ -21,9 +21,10 @@ export interface TimeRange {
 
 export const DEF_TIME_RANGE: TimeRange = {
   recent: 30,
-  begin_time: 0,
-  end_time: 0,
+  begin_time: dayjs().unix() - 30 * 60,
+  end_time: dayjs().unix(),
 }
+
 export interface ITimeRangeSelectorProps {
   value: TimeRange
   onChange: (val: TimeRange) => void

--- a/ui/lib/apps/SlowQuery/utils/useColumn.tsx
+++ b/ui/lib/apps/SlowQuery/utils/useColumn.tsx
@@ -85,12 +85,11 @@ export function useTimestampColumn(
 ): IColumn {
   return {
     name: useCommonColumnName('timestamp'),
-    key: 'timestamp',
+    key: 'Time',
     fieldName: 'timestamp',
     minWidth: 100,
     maxWidth: 150,
     isResizable: true,
-    columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec) => (
       <TextWrap>
         <DateTime.Calendar unixTimestampMs={rec.timestamp * 1000} />


### PR DESCRIPTION
- [x] Order by `Timestamp` by default
- [x] Support search text case-insensitive
- [x] Auto do search when click search button or press `enter`
- [x] Move hook function to `render()` function
- [x] Increase upper bound for avoiding missing rounded timestamp.
- [x] Store all params in router query