### PR TITLE
SlowQuery: use SessionStorage to save search options

### DIFF
--- a/ui/lib/apps/SlowQuery/components/Detail.tsx
+++ b/ui/lib/apps/SlowQuery/components/Detail.tsx
@@ -53,7 +53,7 @@ function DetailPage() {
       <Head
         title={t('slow_query.detail.head.title')}
         back={
-          <Link to={`/slow_query?from=detail`}>
+          <Link to={`/slow_query`}>
             <ArrowLeftOutlined /> {t('slow_query.detail.head.back')}
           </Link>
         }

--- a/ui/lib/apps/SlowQuery/components/List.tsx
+++ b/ui/lib/apps/SlowQuery/components/List.tsx
@@ -1,31 +1,34 @@
 import React, { useState, useEffect } from 'react'
-import { Select, Space, Tooltip, Input } from 'antd'
-import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
 import { useNavigate, useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Select, Space, Tooltip, Input } from 'antd'
+import { ReloadOutlined } from '@ant-design/icons'
+import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
+import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
+import client, { SlowqueryBase } from '@lib/client'
 import { Card, CardTableV2 } from '@lib/components'
+import * as useColumn from '@lib/utils/useColumn'
+import * as useSlowQueryColumn from '../utils/useColumn'
+import DetailPage from './Detail'
 import TimeRangeSelector, {
   TimeRange,
   DEF_TIME_RANGE,
 } from './TimeRangeSelector'
-import { useTranslation } from 'react-i18next'
-import client, { SlowqueryBase } from '@lib/client'
-import { ReloadOutlined } from '@ant-design/icons'
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
-import * as useSlowQueryColumn from '../utils/useColumn'
-import DetailPage from './Detail'
-import * as useColumn from '@lib/utils/useColumn'
 
 import styles from './List.module.less'
 
 const { Option } = Select
 const { Search } = Input
 
+const LIMITS = [100, 200, 500, 1000]
+const SEARCH_OPTIONS_SESSION_KEY = 'slow_query_search_options'
+type OrderBy = 'Query_time' | 'Mem_max' | 'Time'
+
 const tableColumns = (
   rows: SlowqueryBase[],
   onColumnClick: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void,
-  orderBy: string,
+  orderBy: OrderBy,
   desc: boolean
-  // showFullSQL?: boolean
 ): IColumn[] => {
   return [
     useSlowQueryColumn.useSqlColumn(rows),
@@ -54,12 +57,12 @@ export default function List() {
   const [curSchemas, setCurSchemas] = useState<string[]>([])
   const [schemas, setSchemas] = useState<string[]>([])
   const [searchText, setSearchText] = useState('')
-  const [orderBy, setOrderBy] = useState('Query_time')
+  const [orderBy, setOrderBy] = useState<OrderBy>('Query_time')
   const [desc, setDesc] = useState(true)
   const [limit, setLimit] = useState(100)
   const [refreshTimes, setRefreshTimes] = useState(0)
 
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [slowQueryList, setSlowQueryList] = useState<SlowqueryBase[]>([])
 
   const [columns, setColumns] = useState<IColumn[]>([])
@@ -78,6 +81,37 @@ export default function List() {
   }, [])
 
   useEffect(() => {
+    function loadSearchOptions() {
+      const content = sessionStorage.getItem(SEARCH_OPTIONS_SESSION_KEY)
+      if (content !== null) {
+        const searchOptions = JSON.parse(content)
+        setCurTimeRange(searchOptions.curTimeRange)
+        setCurSchemas(searchOptions.curSchemas)
+        setSearchText(searchOptions.searchText)
+        setLimit(searchOptions.limit)
+        setOrderBy(searchOptions.orderBy)
+        setDesc(searchOptions.desc)
+      }
+    }
+    loadSearchOptions()
+  }, [])
+
+  useEffect(() => {
+    function saveSearchOptions() {
+      const searchOptions = JSON.stringify({
+        curTimeRange,
+        curSchemas,
+        searchText,
+        limit,
+        orderBy,
+        desc,
+      })
+      sessionStorage.setItem(SEARCH_OPTIONS_SESSION_KEY, searchOptions)
+    }
+    saveSearchOptions()
+  }, [curTimeRange, curSchemas, searchText, limit, orderBy, desc])
+
+  useEffect(() => {
     async function getSlowQueryList() {
       setLoading(true)
       const res = await client
@@ -92,41 +126,16 @@ export default function List() {
           searchText
         )
       setLoading(false)
-      if (res?.data) {
-        setSlowQueryList(res.data || [])
-      }
+      setSlowQueryList(res?.data || [])
     }
     getSlowQueryList()
   }, [curTimeRange, curSchemas, orderBy, desc, searchText, limit, refreshTimes])
-
-  // TODO: refine
-  const location = useLocation()
-  useEffect(() => {
-    if (location.search === '?from=detail') {
-      // load
-      const searchOptionsStr = localStorage.getItem('slow_query_search_options')
-      if (searchOptionsStr !== null) {
-        const searchOptions = JSON.parse(searchOptionsStr)
-        setCurTimeRange(searchOptions.curTimeRange)
-        setCurSchemas(searchOptions.curSchemas)
-        setSearchText(searchOptions.searchText)
-        setLimit(searchOptions.limit)
-        setOrderBy(searchOptions.orderBy)
-        setDesc(searchOptions.desc)
-      }
-    }
-    // eslint-disable-next-line
-  }, [])
-
-  function handleTimeRangeChange(val: TimeRange) {
-    setCurTimeRange(val)
-  }
 
   function onColumnClick(_ev: React.MouseEvent<HTMLElement>, column: IColumn) {
     if (column.key === orderBy) {
       setDesc(!desc)
     } else {
-      setOrderBy(column.key)
+      setOrderBy(column.key as OrderBy)
       setDesc(true)
     }
   }
@@ -138,17 +147,6 @@ export default function List() {
       time: rec.timestamp,
     })
     navigate(`/slow_query/detail?${qs}`)
-
-    // save search options
-    const searchOptions = JSON.stringify({
-      curTimeRange,
-      curSchemas,
-      orderBy,
-      desc,
-      searchText,
-      limit,
-    })
-    localStorage.setItem('slow_query_search_options', searchOptions)
   }
 
   return (
@@ -158,7 +156,7 @@ export default function List() {
           <Space size="middle" className={styles.search_options}>
             <TimeRangeSelector
               value={curTimeRange}
-              onChange={handleTimeRangeChange}
+              onChange={setCurTimeRange}
             />
             <Select
               value={curSchemas}
@@ -178,15 +176,12 @@ export default function List() {
               value={searchText}
               onChange={(e) => setSearchText(e.target.value)}
             />
-            <Select
-              defaultValue="100"
-              style={{ width: 150 }}
-              onChange={(val) => setLimit(+val!)}
-            >
-              <Option value="100">Limit 100</Option>
-              <Option value="200">Limit 200</Option>
-              <Option value="500">Limit 500</Option>
-              <Option value="1000">Limit 1000</Option>
+            <Select value={limit} style={{ width: 150 }} onChange={setLimit}>
+              {LIMITS.map((item) => (
+                <Option value={item} key={item}>
+                  Limit {item}
+                </Option>
+              ))}
             </Select>
           </Space>
           <Space size="middle" className={styles.right_actions}>


### PR DESCRIPTION
Fix #411 , will do it for the statements page as well later.