### PR TITLE
slow_query: fix bugs in slow query page

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -131,7 +131,7 @@ func QuerySlowLogList(db *gorm.DB, params *QueryRequestParam) ([]Base, error) {
 	tx = tx.Where("time between from_unixtime(?) and from_unixtime(?)", params.LogStartTS, params.LogEndTS)
 	if params.Text != "" {
 		lowerStr := strings.ToLower(params.Text)
-		tx = tx.Where("txn_start_ts REGEXP ? OR LOWER(digest) REGEXP ? OR LOWER(prev_stmt) REGEXP ? OR LOWER(query) REGEXP ?",
+		tx = tx.Where("txn_start_ts REGEXP ? OR LOWER(digest) REGEXP ? OR LOWER(CONVERT(prev_stmt USING utf8)) REGEXP ? OR LOWER(CONVERT(query USING utf8)) REGEXP ?",
 			lowerStr,
 			lowerStr,
 			lowerStr,
@@ -163,11 +163,11 @@ func QuerySlowLogList(db *gorm.DB, params *QueryRequestParam) ([]Base, error) {
 
 func QuerySlowLogDetail(db *gorm.DB, req *DetailRequest) (*SlowQuery, error) {
 	var result SlowQuery
-	upperBound := req.Time + 10E-7
-	lowerBound := req.Time - 10E-7
+	// upperBound := req.Time + 10E-7
+	// lowerBound := req.Time - 10E-7
 	err := db.Select(SelectStmt).Table(SlowQueryTable).
 		Where("Digest = ?", req.Digest).
-		Where("Time >= from_unixtime(?) and Time <= from_unixtime(?)", lowerBound, upperBound).
+		Where("Time = from_unixtime(?)", req.Time).
 		Where("Conn_id = ?", req.ConnectID).
 		First(&result).Error
 	if err != nil {

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -163,8 +163,6 @@ func QuerySlowLogList(db *gorm.DB, params *QueryRequestParam) ([]Base, error) {
 
 func QuerySlowLogDetail(db *gorm.DB, req *DetailRequest) (*SlowQuery, error) {
 	var result SlowQuery
-	// upperBound := req.Time + 10E-7
-	// lowerBound := req.Time - 10E-7
 	err := db.Select(SelectStmt).Table(SlowQueryTable).
 		Where("Digest = ?", req.Digest).
 		Where("Time = from_unixtime(?)", req.Time).

--- a/ui/lib/apps/SlowQuery/components/List.tsx
+++ b/ui/lib/apps/SlowQuery/components/List.tsx
@@ -67,7 +67,8 @@ function List() {
       setLoading(true)
       const recentMins = searchOptions.timeRange.recent
       if (recentMins > 0) {
-        // beginTime & endTime may outdated, update to recent time range
+        // beginTime & endTime is fixed value,
+        // so update them to the time range from now
         const now = dayjs().unix()
         const beginTime = now - recentMins * 60
         searchOptions.timeRange = {

--- a/ui/lib/apps/SlowQuery/components/List.tsx
+++ b/ui/lib/apps/SlowQuery/components/List.tsx
@@ -13,6 +13,7 @@ import TimeRangeSelector, {
 import SlowQueriesTable, { OrderBy } from './SlowQueriesTable'
 
 import styles from './List.module.less'
+import dayjs from 'dayjs'
 
 const { Option } = Select
 const { Search } = Input
@@ -64,6 +65,17 @@ function List() {
   useEffect(() => {
     async function getSlowQueryList() {
       setLoading(true)
+      const recentMins = searchOptions.timeRange.recent
+      if (recentMins > 0) {
+        // beginTime & endTime may outdated, update to recent time range
+        const now = dayjs().unix()
+        const beginTime = now - recentMins * 60
+        searchOptions.timeRange = {
+          recent: recentMins,
+          begin_time: beginTime,
+          end_time: now,
+        }
+      }
       const res = await client
         .getInstance()
         .slowQueryListGet(


### PR DESCRIPTION
Bugfix:
- [x] Fix bug in case-insensitive keyword search
- [x] Fix bug in time range selector, now we use recent 30 minutes time range instead of **fixed** 30 minutes time range.

Improvement:
- [x] After pingcap/tidb#16806 merged, now we can check if `cluster_slow_query.time` is equal to given time string by `=` operator.