### PR TITLE
cluster_info: fix UI bug in cluster_info

### DIFF
--- a/ui/lib/apps/ClusterInfo/components/HostTable.js
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.js
@@ -213,6 +213,7 @@ export default function HostTable() {
 
   return (
     <CardTableV2
+      cardNoMargin
       loading={isLoading}
       columns={columns}
       items={tableData || []}

--- a/ui/lib/apps/ClusterInfo/components/InstanceTable.js
+++ b/ui/lib/apps/ClusterInfo/components/InstanceTable.js
@@ -207,6 +207,7 @@ export default function ListPage() {
 
   return (
     <CardTableV2
+      cardNoMargin
       loading={isLoading}
       columns={columns}
       items={tableData || []}

--- a/ui/lib/apps/ClusterInfo/pages/List.js
+++ b/ui/lib/apps/ClusterInfo/pages/List.js
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import HostTable from '../components/HostTable'
 import InstanceTable from '../components/InstanceTable'
 import CardTabs from '@lib/components/CardTabs'
+import { Card } from '@lib/components'
 
 function renderTabBar(props, DefaultTabBar) {
   return (
@@ -21,29 +22,30 @@ export default function ListPage() {
   const { t } = useTranslation()
 
   return (
-    <ScrollablePane>
-      <CardTabs
-        defaultActiveKey={tabKey}
-        onChange={(key) => {
-          navigate(`/cluster_info/${key}`)
-        }}
-        renderTabBar={renderTabBar}
-        tabBarStyle={{ margin: 48, marginBottom: 0 }}
-        animated={false}
-      >
-        <CardTabs.TabPane
-          tab={t('cluster_info.list.instance_table.title')}
-          key="instance"
+    <ScrollablePane style={{ height: '100vh' }}>
+      <Card>
+        <CardTabs
+          defaultActiveKey={tabKey}
+          onChange={(key) => {
+            navigate(`/cluster_info/${key}`)
+          }}
+          renderTabBar={renderTabBar}
+          animated={false}
         >
-          <InstanceTable />
-        </CardTabs.TabPane>
-        <CardTabs.TabPane
-          tab={t('cluster_info.list.host_table.title')}
-          key="host"
-        >
-          <HostTable />
-        </CardTabs.TabPane>
-      </CardTabs>
+          <CardTabs.TabPane
+            tab={t('cluster_info.list.instance_table.title')}
+            key="instance"
+          >
+            <InstanceTable />
+          </CardTabs.TabPane>
+          <CardTabs.TabPane
+            tab={t('cluster_info.list.host_table.title')}
+            key="host"
+          >
+            <HostTable />
+          </CardTabs.TabPane>
+        </CardTabs>
+      </Card>
     </ScrollablePane>
   )
 }


### PR DESCRIPTION
Bugfix:
- [x] Remove extra space on the right of page in cluster info page.

![image](https://user-images.githubusercontent.com/9463871/80439266-afdea780-8938-11ea-93e6-e8fdd23dedd1.png)
