### PR TITLE
Remember columns width

### DIFF
--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Space, Tooltip, Drawer, Button, Checkbox, Result } from 'antd'
-import { useLocalStorageState } from '@umijs/hooks'
+import { useLocalStorageState, useDebounceFn } from '@umijs/hooks'
 import { SettingOutlined, ReloadOutlined } from '@ant-design/icons'
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
@@ -15,6 +15,7 @@ const { Option } = Select
 
 const VISIBLE_COLUMN_KEYS = 'statement.visible_column_keys'
 const SHOW_FULL_SQL = 'statement.show_full_sql'
+const COLUMNS_WIDTH = 'statement.columns_width'
 
 const defColumnKeys: IColumnKeys = {
   digest_text: true,
@@ -43,6 +44,7 @@ export default function StatementsOverview() {
 
   const [columns, setColumns] = useState<IColumn[]>([])
   const [showSettings, setShowSettings] = useState(false)
+
   const [visibleColumnKeys, setVisibleColumnKeys] = useLocalStorageState(
     VISIBLE_COLUMN_KEYS,
     defColumnKeys
@@ -51,6 +53,22 @@ export default function StatementsOverview() {
     SHOW_FULL_SQL,
     false
   )
+
+  const [columnsWidth, setColumnsWidth] = useLocalStorageState(
+    COLUMNS_WIDTH,
+    {}
+  )
+  function handleColumnResize(
+    column?: IColumn,
+    newWidth?: number,
+    _columnIndex?: number
+  ) {
+    setColumnsWidth({
+      ...columnsWidth,
+      [column!.key]: newWidth,
+    })
+  }
+  const { run } = useDebounceFn(handleColumnResize, 500)
 
   return (
     <ScrollablePane style={{ height: '100vh' }}>
@@ -155,6 +173,8 @@ export default function StatementsOverview() {
               desc,
             })
           }
+          columnsWidth={columnsWidth}
+          onColumnResize={run}
         />
       ) : (
         <Result

--- a/ui/lib/components/CardTableV2/index.tsx
+++ b/ui/lib/components/CardTableV2/index.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useMemo } from 'react'
-import { Skeleton, Checkbox } from 'antd'
+import { Checkbox } from 'antd'
 import cx from 'classnames'
 import {
-  DetailsList,
   DetailsListLayoutMode,
   SelectionMode,
   IDetailsListProps,
 } from 'office-ui-fabric-react/lib/DetailsList'
+import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList'
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
 
 import Card from '../Card'
@@ -18,7 +18,6 @@ export interface ICardTableV2Props extends IDetailsListProps {
   className?: string
   style?: object
   loading?: boolean
-  loadingSkeletonRows?: number
   cardExtra?: React.ReactNode
   cardNoMargin?: boolean
   // The keys of visible columns. If null, all columns will be shown.
@@ -65,7 +64,6 @@ function CardTableV2(props: ICardTableV2Props) {
     className,
     style,
     loading = false,
-    loadingSkeletonRows = 5,
     cardExtra,
     cardNoMargin,
     visibleColumnKeys,
@@ -101,28 +99,21 @@ function CardTableV2(props: ICardTableV2Props) {
       noMargin={cardNoMargin}
       extra={cardExtra}
     >
-      {loading ? (
-        <Skeleton
-          active
-          title={false}
-          paragraph={{ rows: loadingSkeletonRows }}
+      <div className={styles.cardTableContent}>
+        <ShimmeredDetailsList
+          selectionMode={SelectionMode.none}
+          layoutMode={DetailsListLayoutMode.justified}
+          onRenderDetailsHeader={renderStickyHeader}
+          onRenderRow={onRowClicked ? renderClickableRow : undefined}
+          onRenderCheckbox={(props) => {
+            return <Checkbox checked={props?.checked} />
+          }}
+          columns={filteredColumns}
+          items={filteredItems}
+          enableShimmer={filteredItems.length > 0 ? false : loading}
+          {...restProps}
         />
-      ) : (
-        <div className={styles.cardTableContent}>
-          <DetailsList
-            selectionMode={SelectionMode.none}
-            layoutMode={DetailsListLayoutMode.justified}
-            onRenderDetailsHeader={renderStickyHeader}
-            onRenderRow={onRowClicked ? renderClickableRow : undefined}
-            onRenderCheckbox={(props) => {
-              return <Checkbox checked={props?.checked} />
-            }}
-            columns={filteredColumns}
-            items={filteredItems}
-            {...restProps}
-          />
-        </div>
-      )}
+      </div>
     </Card>
   )
 }


### PR DESCRIPTION
resolve #444 

What did:

- Use ShimmeredDetailsList to represent loading status for not re-mount the DatailsList when reloading data
- Keep changed columns width when reloading data in the current page
- Show the existed old data when reloading

Failed to do:

- Persist the width of the columns.

  According to the issue https://github.com/microsoft/fluentui/issues/9287 , this feature isn't supported by DatailsList.

![44](https://user-images.githubusercontent.com/1284531/81166403-32650800-8fc6-11ea-858e-b5a34a6d02fe.gif)

Do you guys have any idea?