### PR TITLE
Refine order and desc

### DIFF
--- a/ui/lib/apps/ClusterInfo/components/HostTable.js
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.js
@@ -1,4 +1,5 @@
 import { WarningOutlined } from '@ant-design/icons'
+import { ColumnActionsMode } from 'office-ui-fabric-react/lib/DetailsList'
 import { getValueFormat } from '@baurine/grafana-value-formats'
 import client from '@lib/client'
 import { Bar, CardTableV2 } from '@lib/components'
@@ -32,6 +33,7 @@ export default function HostTable() {
       maxWidth: 200,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ ip, unavailable }) => {
         if (unavailable) {
           return (
@@ -54,6 +56,7 @@ export default function HostTable() {
       maxWidth: 100,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ cpu_core }) =>
         cpu_core !== undefined ? `${cpu_core} vCPU` : '',
     },
@@ -64,6 +67,7 @@ export default function HostTable() {
       maxWidth: 150,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ cpu_usage }) => {
         if (cpu_usage === undefined) {
           return
@@ -90,6 +94,7 @@ export default function HostTable() {
       maxWidth: 100,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ memory }) =>
         memory !== undefined ? getValueFormat('bytes')(memory.total, 1) : '',
     },
@@ -100,6 +105,7 @@ export default function HostTable() {
       maxWidth: 150,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ memory }) => {
         if (memory === undefined) {
           return
@@ -126,6 +132,7 @@ export default function HostTable() {
       maxWidth: 200,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ partitions }) => {
         if (partitions === undefined || partitions.length === 0) {
           return
@@ -170,6 +177,7 @@ export default function HostTable() {
       maxWidth: 100,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ partitions }) => {
         if (partitions === undefined || partitions.length === 0) {
           return
@@ -190,6 +198,7 @@ export default function HostTable() {
       maxWidth: 150,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ partitions }) => {
         if (partitions === undefined || partitions.length === 0) {
           return

--- a/ui/lib/apps/ClusterInfo/components/InstanceTable.js
+++ b/ui/lib/apps/ClusterInfo/components/InstanceTable.js
@@ -1,4 +1,5 @@
 import { DeleteOutlined } from '@ant-design/icons'
+import { ColumnActionsMode } from 'office-ui-fabric-react/lib/DetailsList'
 import {
   STATUS_DOWN,
   STATUS_OFFLINE,
@@ -153,6 +154,7 @@ export default function ListPage() {
       minWidth: 100,
       maxWidth: 200,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: (node) => (
         <Tooltip title={`${node.ip}:${node.port}`}>
           {node.ip}:{node.port}
@@ -165,6 +167,7 @@ export default function ListPage() {
       minWidth: 100,
       maxWidth: 150,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: renderStatusColumn,
     },
     {
@@ -173,6 +176,7 @@ export default function ListPage() {
       minWidth: 150,
       maxWidth: 200,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ start_timestamp: ts }) => {
         if (ts !== undefined && ts !== 0) {
           return <DateTime.Calendar unixTimestampMs={ts * 1000} />
@@ -186,6 +190,7 @@ export default function ListPage() {
       minWidth: 150,
       maxWidth: 300,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
     },
     {
       name: t('cluster_info.list.instance_table.columns.deploy_path'),
@@ -194,6 +199,7 @@ export default function ListPage() {
       minWidth: 150,
       maxWidth: 300,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
     },
     {
       name: t('cluster_info.list.instance_table.columns.git_hash'),
@@ -202,6 +208,7 @@ export default function ListPage() {
       minWidth: 150,
       maxWidth: 300,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
     },
   ]
 

--- a/ui/lib/apps/Diagnose/components/DiagnoseHistory.tsx
+++ b/ui/lib/apps/Diagnose/components/DiagnoseHistory.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Badge } from 'antd'
 import { useTranslation } from 'react-i18next'
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
+import {
+  IColumn,
+  ColumnActionsMode,
+} from 'office-ui-fabric-react/lib/DetailsList'
 import dayjs from 'dayjs'
 import { CardTableV2, DateTime } from '@lib/components'
 import client, { DiagnoseReport } from '@lib/client'
@@ -17,6 +20,7 @@ const tableColumns = (t: TFunction): IColumn[] => [
     minWidth: 200,
     maxWidth: 350,
     isResizable: true,
+    columnActionsMode: ColumnActionsMode.disabled,
   },
   {
     name: t('diagnose.list_table.diagnose_create_time'),
@@ -24,6 +28,7 @@ const tableColumns = (t: TFunction): IColumn[] => [
     minWidth: 100,
     maxWidth: 200,
     isResizable: true,
+    columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec) => (
       <DateTime.Calendar unixTimestampMs={dayjs(rec.CreatedAt).unix() * 1000} />
     ),
@@ -34,6 +39,7 @@ const tableColumns = (t: TFunction): IColumn[] => [
     minWidth: 100,
     maxWidth: 150,
     isResizable: true,
+    columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec: DiagnoseReport) => {
       if (rec.progress! < 100) {
         return (
@@ -58,6 +64,7 @@ const tableColumns = (t: TFunction): IColumn[] => [
     minWidth: 200,
     maxWidth: 350,
     isResizable: true,
+    columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec: DiagnoseReport) => {
       return (
         <span>
@@ -78,6 +85,7 @@ const tableColumns = (t: TFunction): IColumn[] => [
     minWidth: 200,
     maxWidth: 350,
     isResizable: true,
+    columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec: DiagnoseReport) =>
       rec.compare_start_time && (
         <span>

--- a/ui/lib/apps/InstanceProfiling/pages/List.js
+++ b/ui/lib/apps/InstanceProfiling/pages/List.js
@@ -3,6 +3,7 @@ import { message, Form, TreeSelect, Button, Select, Badge } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
+import { ColumnActionsMode } from 'office-ui-fabric-react/lib/DetailsList'
 import { Card, CardTableV2 } from '@lib/components'
 import client from '@lib/client'
 import { useClientRequest } from '@lib/utils/useClientRequest'
@@ -140,6 +141,7 @@ export default function Page() {
       minWidth: 150,
       maxWidth: 250,
       isResizable: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: (rec) => {
         // TODO: Extract to utility function
         const r = []
@@ -162,6 +164,7 @@ export default function Page() {
       maxWidth: 150,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: (rec) => {
         if (rec.state === 1) {
           return (
@@ -187,6 +190,7 @@ export default function Page() {
       maxWidth: 220,
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
       onRender: (rec) => {
         return <DateTime.Calendar unixTimestampMs={rec.started_at * 1000} />
       },
@@ -199,6 +203,7 @@ export default function Page() {
       fieldName: 'profile_duration_secs',
       isResizable: true,
       isCollapsible: true,
+      columnActionsMode: ColumnActionsMode.disabled,
     },
   ]
 

--- a/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
+++ b/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
@@ -1,50 +1,26 @@
-import React, { useEffect } from 'react'
+import React, { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
 import { CardTableV2, ICardTableV2Props } from '@lib/components'
 import { SlowqueryBase } from '@lib/client'
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
 import * as useColumn from '@lib/utils/useColumn'
 
 import * as useSlowQueryColumn from '../utils/useColumn'
 import DetailPage from '../pages/Detail'
 
-function tableColumns(
-  rows: SlowqueryBase[],
-  onColumnClick: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void,
-  orderBy: string,
-  desc: boolean,
-  showFullSQL?: boolean
-): IColumn[] {
+function tableColumns(rows: SlowqueryBase[], showFullSQL?: boolean): IColumn[] {
   return [
     useSlowQueryColumn.useSqlColumn(rows, showFullSQL),
     useSlowQueryColumn.useDigestColumn(rows),
     useSlowQueryColumn.useInstanceColumn(rows),
     useSlowQueryColumn.useDBColumn(rows),
     useSlowQueryColumn.useSuccessColumn(rows),
-    {
-      ...useSlowQueryColumn.useTimestampColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useSlowQueryColumn.useQueryTimeColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useSlowQueryColumn.useParseTimeColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useSlowQueryColumn.useCompileTimeColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useSlowQueryColumn.useProcessTimeColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useSlowQueryColumn.useMemoryColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
+    useSlowQueryColumn.useTimestampColumn(rows),
+    useSlowQueryColumn.useQueryTimeColumn(rows),
+    useSlowQueryColumn.useParseTimeColumn(rows),
+    useSlowQueryColumn.useCompileTimeColumn(rows),
+    useSlowQueryColumn.useProcessTimeColumn(rows),
+    useSlowQueryColumn.useMemoryColumn(rows),
     useSlowQueryColumn.useTxnStartTsColumn(rows),
     useColumn.useDummyColumn(),
   ]
@@ -53,49 +29,22 @@ function tableColumns(
 interface Props extends Partial<ICardTableV2Props> {
   loading: boolean
   slowQueries: SlowqueryBase[]
-
-  orderBy: string
-  desc: boolean
   showFullSQL?: boolean
-
-  onChangeSort: (orderBy: string, desc: boolean) => void
-  onGetColumns?: (columns: IColumn[]) => void
 }
 
 export default function SlowQueriesTable({
   loading,
   slowQueries,
-
-  orderBy,
-  desc,
   showFullSQL,
 
-  onChangeSort,
-  onGetColumns,
   ...restProps
 }: Props) {
   const navigate = useNavigate()
 
-  const columns = tableColumns(
+  const columns = useMemo(() => tableColumns(slowQueries, showFullSQL), [
     slowQueries,
-    onColumnClick,
-    orderBy,
-    desc,
-    showFullSQL
-  )
-
-  useEffect(() => {
-    onGetColumns && onGetColumns(columns)
-    // eslint-disable-next-line
-  }, [])
-
-  function onColumnClick(_ev: React.MouseEvent<HTMLElement>, column: IColumn) {
-    if (column.key === orderBy) {
-      onChangeSort(orderBy, !desc)
-    } else {
-      onChangeSort(column.key, true)
-    }
-  }
+    showFullSQL,
+  ])
 
   function handleRowClick(rec) {
     const qs = DetailPage.buildQuery({
@@ -108,11 +57,11 @@ export default function SlowQueriesTable({
 
   return (
     <CardTableV2
+      {...restProps}
       loading={loading}
       columns={columns}
-      onRowClicked={handleRowClick}
-      {...restProps}
       items={slowQueries}
+      onRowClicked={handleRowClick}
     />
   )
 }

--- a/ui/lib/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/lib/apps/SlowQuery/pages/List/index.tsx
@@ -142,6 +142,8 @@ function List() {
         orderBy={savedQueryOptions.orderBy}
         desc={savedQueryOptions.desc}
         showFullSQL={showFullSQL}
+        visibleColumnKeys={visibleColumnKeys}
+        onGetColumns={setColumns}
         onChangeSort={(orderBy, desc) =>
           setSavedQueryOptions({
             ...savedQueryOptions,
@@ -149,8 +151,6 @@ function List() {
             desc,
           })
         }
-        onGetColumns={setColumns}
-        visibleColumnKeys={visibleColumnKeys}
       />
     </ScrollablePane>
   )

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -67,7 +67,7 @@ slow_query:
       txn_retry: Transaction Retries
     status:
       success: Success
-      failed: Failed
+      error: Failed
   detail:
     head:
       title: Slow Query Detail

--- a/ui/lib/apps/SlowQuery/translations/zh-CN.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh-CN.yaml
@@ -69,7 +69,7 @@ slow_query:
       txn_retry: 事务重试次数
     status:
       success: 成功
-      failed: 失败
+      error: 失败
   detail:
     head:
       title: 慢查询详情

--- a/ui/lib/apps/SlowQuery/utils/useColumn.tsx
+++ b/ui/lib/apps/SlowQuery/utils/useColumn.tsx
@@ -134,8 +134,8 @@ export function useDBColumn(
 export function useSuccessColumn(
   _rows?: { success?: number }[] // used for type check only
 ): IColumn {
-  // !! Wrong usage, hooks only can be used inside the Function Component
-  // !! Can't be used in normal function
+  // !! Don't call `useTranslation()` directly to avoid this method become the custom hook
+  // !! So we can use this inside the useMemo(), useEffect() and useState(()=>{...})
   // const { t } = useTranslation()
   return {
     name: useCommonColumnName('result'),

--- a/ui/lib/apps/SlowQuery/utils/useColumn.tsx
+++ b/ui/lib/apps/SlowQuery/utils/useColumn.tsx
@@ -16,7 +16,7 @@ import { getValueFormat } from '@baurine/grafana-value-formats'
 import { max } from 'lodash'
 import { useTranslation } from 'react-i18next'
 
-function SuccessStatusBadge({ status }: { status: 'success' | 'error' }) {
+function ResultStatusBadge({ status }: { status: 'success' | 'error' }) {
   const { t } = useTranslation()
   return (
     <Badge status={status} text={t(`slow_query.common.status.${status}`)} />
@@ -146,7 +146,7 @@ export function useSuccessColumn(
     isResizable: true,
     columnActionsMode: ColumnActionsMode.disabled,
     onRender: (rec) => (
-      <SuccessStatusBadge status={rec.success === 1 ? 'success' : 'error'} />
+      <ResultStatusBadge status={rec.success === 1 ? 'success' : 'error'} />
     ),
   }
 }

--- a/ui/lib/apps/SlowQuery/utils/useColumn.tsx
+++ b/ui/lib/apps/SlowQuery/utils/useColumn.tsx
@@ -16,6 +16,13 @@ import { getValueFormat } from '@baurine/grafana-value-formats'
 import { max } from 'lodash'
 import { useTranslation } from 'react-i18next'
 
+function SuccessStatusBadge({ status }: { status: 'success' | 'error' }) {
+  const { t } = useTranslation()
+  return (
+    <Badge status={status} text={t(`slow_query.common.status.${status}`)} />
+  )
+}
+
 function useCommonColumnName(fieldName: string): any {
   return (
     <TextWithInfo.TransKey
@@ -127,7 +134,9 @@ export function useDBColumn(
 export function useSuccessColumn(
   _rows?: { success?: number }[] // used for type check only
 ): IColumn {
-  const { t } = useTranslation()
+  // !! Wrong usage, hooks only can be used inside the Function Component
+  // !! Can't be used in normal function
+  // const { t } = useTranslation()
   return {
     name: useCommonColumnName('result'),
     key: 'Succ',
@@ -136,19 +145,14 @@ export function useSuccessColumn(
     maxWidth: 150,
     isResizable: true,
     columnActionsMode: ColumnActionsMode.disabled,
-    onRender: (rec) =>
-      rec.success === 1 ? (
-        <Badge status="success" text={t(`slow_query.common.status.success`)} />
-      ) : (
-        <Badge status="error" text={t(`slow_query.common.status.failed`)} />
-      ),
+    onRender: (rec) => (
+      <SuccessStatusBadge status={rec.success === 1 ? 'success' : 'error'} />
+    ),
   }
 }
 
 export function useTimestampColumn(
-  _rows?: { timestamp?: number }[], // used for type check only
-  orderBy?: string,
-  desc?: boolean
+  _rows?: { timestamp?: number }[] // used for type check only
 ): IColumn {
   const key = 'Time'
   return {
@@ -158,8 +162,6 @@ export function useTimestampColumn(
     minWidth: 100,
     maxWidth: 150,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <TextWrap>
         <DateTime.Calendar unixTimestampMs={rec.timestamp * 1000} />
@@ -168,11 +170,7 @@ export function useTimestampColumn(
   }
 }
 
-export function useQueryTimeColumn(
-  rows?: { query_time?: number }[],
-  orderBy?: string,
-  desc?: boolean
-): IColumn {
+export function useQueryTimeColumn(rows?: { query_time?: number }[]): IColumn {
   const capacity = rows ? max(rows.map((v) => v.query_time)) ?? 0 : 0
   const key = 'Query_time'
   return {
@@ -182,8 +180,6 @@ export function useQueryTimeColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.query_time} capacity={capacity}>
         {getValueFormat('s')(rec.query_time, 1)}
@@ -192,11 +188,7 @@ export function useQueryTimeColumn(
   }
 }
 
-export function useParseTimeColumn(
-  rows?: { parse_time?: number }[],
-  orderBy?: string,
-  desc?: boolean
-): IColumn {
+export function useParseTimeColumn(rows?: { parse_time?: number }[]): IColumn {
   const capacity = rows ? max(rows.map((v) => v.parse_time)) ?? 0 : 0
   const key = 'Parse_time'
   return {
@@ -206,8 +198,6 @@ export function useParseTimeColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.parse_time} capacity={capacity}>
         {getValueFormat('s')(rec.parse_time, 1)}
@@ -217,9 +207,7 @@ export function useParseTimeColumn(
 }
 
 export function useCompileTimeColumn(
-  rows?: { compile_time?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { compile_time?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.compile_time)) ?? 0 : 0
   const key = 'Compile_time'
@@ -230,8 +218,6 @@ export function useCompileTimeColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.compile_time} capacity={capacity}>
         {getValueFormat('s')(rec.compile_time, 1)}
@@ -241,9 +227,7 @@ export function useCompileTimeColumn(
 }
 
 export function useProcessTimeColumn(
-  rows?: { process_time?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { process_time?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.process_time)) ?? 0 : 0
   const key = 'Process_time'
@@ -254,8 +238,6 @@ export function useProcessTimeColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.process_time} capacity={capacity}>
         {getValueFormat('s')(rec.process_time, 1)}
@@ -264,11 +246,7 @@ export function useProcessTimeColumn(
   }
 }
 
-export function useMemoryColumn(
-  rows?: { memory_max?: number }[],
-  orderBy?: string,
-  desc?: boolean
-): IColumn {
+export function useMemoryColumn(rows?: { memory_max?: number }[]): IColumn {
   const capacity = rows ? max(rows.map((v) => v.memory_max)) ?? 0 : 0
   const key = 'Mem_max'
   return {
@@ -278,8 +256,6 @@ export function useMemoryColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: orderBy === key,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.memory_max} capacity={capacity}>
         {getValueFormat('bytes')(rec.memory_max, 1)}

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -1,130 +1,54 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
 import { CardTableV2, ICardTableV2Props } from '@lib/components'
 import { StatementTimeRange, StatementModel } from '@lib/client'
-import DetailPage from '../pages/Detail'
+import * as useColumn from '@lib/utils/useColumn'
+
 import * as useStatementColumn from '../utils/useColumn'
+import DetailPage from '../pages/Detail'
 
 const tableColumns = (
   rows: StatementModel[],
-  onColumnClick: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void,
-  orderBy?: string,
-  desc?: boolean,
   showFullSQL?: boolean
 ): IColumn[] => {
   const columns: IColumn[] = [
     useStatementColumn.useDigestColumn(rows, showFullSQL),
-    {
-      ...useStatementColumn.useSumLatencyColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useAvgMinMaxLatencyColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useExecCountColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useAvgMaxMemColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useErrorsWarningsColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useAvgParseLatencyColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useAvgCompileLatencyColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
-    {
-      ...useStatementColumn.useAvgCoprColumn(rows, orderBy, desc),
-      onColumnClick: onColumnClick,
-    },
+    useStatementColumn.useSumLatencyColumn(rows),
+    useStatementColumn.useAvgMinMaxLatencyColumn(rows),
+    useStatementColumn.useExecCountColumn(rows),
+    useStatementColumn.useAvgMaxMemColumn(rows),
+    useStatementColumn.useErrorsWarningsColumn(rows),
+    useStatementColumn.useAvgParseLatencyColumn(rows),
+    useStatementColumn.useAvgCompileLatencyColumn(rows),
+    useStatementColumn.useAvgCoprColumn(rows),
     useStatementColumn.useRelatedSchemasColumn(rows),
+    useColumn.useDummyColumn(),
   ]
   return columns
-}
-
-function copyAndSort<T>(
-  items: T[],
-  columnKey: string,
-  isSortedDescending?: boolean
-): T[] {
-  const key = columnKey as keyof T
-  return items
-    .slice(0)
-    .sort((a: T, b: T) =>
-      (isSortedDescending ? a[key] < b[key] : a[key] > b[key]) ? 1 : -1
-    )
 }
 
 interface Props extends Partial<ICardTableV2Props> {
   loading: boolean
   statements: StatementModel[]
   timeRange: StatementTimeRange
-  orderBy?: string
-  desc?: boolean
   showFullSQL?: boolean
-
-  onChangeSort: (orderBy: string, desc: boolean) => void
-  onGetColumns?: (columns: IColumn[]) => void
 }
 
 export default function StatementsTable({
   loading,
   statements,
   timeRange,
-  orderBy,
-  desc,
   showFullSQL,
 
-  onChangeSort,
-  onGetColumns,
   ...restPrpos
 }: Props) {
   const navigate = useNavigate()
 
-  // const [columns, setColumns] = useState(
-  //   tableColumns(statements, onColumnClick, orderBy, desc, showFullSQL)
-  // )
-  // `useState(() => tableColumns(...))` will cause run-time crash, the message:
-  // Warning: Do not call Hooks inside useEffect(...), useMemo(...),
-  // or other built-in Hooks. You can only call Hooks at the top level of your React function.
-  // I guess because we use the `useTranslation()` inside the `tableColumns()` method
-  // TODO: verify
-
-  const columns = tableColumns(
+  const columns = useMemo(() => tableColumns(statements, showFullSQL), [
     statements,
-    onColumnClick,
-    orderBy,
-    desc,
-    showFullSQL
-  )
-
-  const items = useMemo(() => {
-    const curColumn = columns.find((col) => col.key === orderBy)
-    if (curColumn) {
-      return copyAndSort(
-        statements,
-        curColumn.fieldName!,
-        curColumn.isSortedDescending
-      )
-    }
-    return statements
-    // eslint-disable-next-line
-  }, [statements, orderBy, desc])
-
-  useEffect(() => {
-    onGetColumns && onGetColumns(columns)
-    // eslint-disable-next-line
-  }, [])
+    showFullSQL,
+  ])
 
   function handleRowClick(rec) {
     const qs = DetailPage.buildQuery({
@@ -136,21 +60,13 @@ export default function StatementsTable({
     navigate(`/statement/detail?${qs}`)
   }
 
-  function onColumnClick(_ev: React.MouseEvent<HTMLElement>, column: IColumn) {
-    if (column.key === orderBy) {
-      onChangeSort(orderBy, !desc)
-    } else {
-      onChangeSort(column.key, true)
-    }
-  }
-
   return (
     <CardTableV2
+      {...restPrpos}
       loading={loading}
       columns={columns}
+      items={statements}
       onRowClicked={handleRowClick}
-      {...restPrpos}
-      items={items}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -12,7 +12,7 @@ const tableColumns = (
   rows: StatementModel[],
   showFullSQL?: boolean
 ): IColumn[] => {
-  const columns: IColumn[] = [
+  return [
     useStatementColumn.useDigestColumn(rows, showFullSQL),
     useStatementColumn.useSumLatencyColumn(rows),
     useStatementColumn.useAvgMinMaxLatencyColumn(rows),
@@ -25,7 +25,6 @@ const tableColumns = (
     useStatementColumn.useRelatedSchemasColumn(rows),
     useColumn.useDummyColumn(),
   ]
-  return columns
 }
 
 interface Props extends Partial<ICardTableV2Props> {

--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -140,8 +140,8 @@ export default function StatementsOverview() {
 
       {enable ? (
         <StatementsTable
-          statements={statements}
           loading={loadingStatements}
+          statements={statements}
           timeRange={validTimeRange}
           orderBy={savedQueryOptions.orderBy}
           desc={savedQueryOptions.desc}

--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Space, Tooltip, Drawer, Button, Checkbox, Result } from 'antd'
-import { useLocalStorageState, useDebounceFn } from '@umijs/hooks'
+import { useLocalStorageState } from '@umijs/hooks'
 import { SettingOutlined, ReloadOutlined } from '@ant-design/icons'
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList'
@@ -15,7 +15,6 @@ const { Option } = Select
 
 const VISIBLE_COLUMN_KEYS = 'statement.visible_column_keys'
 const SHOW_FULL_SQL = 'statement.show_full_sql'
-const COLUMNS_WIDTH = 'statement.columns_width'
 
 const defColumnKeys: IColumnKeys = {
   digest_text: true,
@@ -44,7 +43,6 @@ export default function StatementsOverview() {
 
   const [columns, setColumns] = useState<IColumn[]>([])
   const [showSettings, setShowSettings] = useState(false)
-
   const [visibleColumnKeys, setVisibleColumnKeys] = useLocalStorageState(
     VISIBLE_COLUMN_KEYS,
     defColumnKeys
@@ -53,22 +51,6 @@ export default function StatementsOverview() {
     SHOW_FULL_SQL,
     false
   )
-
-  const [columnsWidth, setColumnsWidth] = useLocalStorageState(
-    COLUMNS_WIDTH,
-    {}
-  )
-  function handleColumnResize(
-    column?: IColumn,
-    newWidth?: number,
-    _columnIndex?: number
-  ) {
-    setColumnsWidth({
-      ...columnsWidth,
-      [column!.key]: newWidth,
-    })
-  }
-  const { run } = useDebounceFn(handleColumnResize, 500)
 
   return (
     <ScrollablePane style={{ height: '100vh' }}>
@@ -173,8 +155,6 @@ export default function StatementsOverview() {
               desc,
             })
           }
-          columnsWidth={columnsWidth}
-          onColumnResize={run}
         />
       ) : (
         <Result

--- a/ui/lib/apps/Statement/utils/useColumn.tsx
+++ b/ui/lib/apps/Statement/utils/useColumn.tsx
@@ -64,9 +64,7 @@ export function useDigestColumn(
 }
 
 export function useSumLatencyColumn(
-  rows?: { sum_latency?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { sum_latency?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.sum_latency)) ?? 0 : 0
   const key = 'sum_latency'
@@ -77,8 +75,6 @@ export function useSumLatencyColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.sum_latency} capacity={capacity}>
         {getValueFormat('ns')(rec.sum_latency, 1)}
@@ -88,21 +84,17 @@ export function useSumLatencyColumn(
 }
 
 export function useAvgMinMaxLatencyColumn(
-  rows?: { max_latency?: number; min_latency?: number; avg_latency?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { max_latency?: number; min_latency?: number; avg_latency?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.max_latency)) ?? 0 : 0
   const key = 'avg_latency'
   return {
-    name: useCommonColumnName('avg_latency'),
+    name: useCommonColumnName(key),
     key,
-    fieldName: 'avg_latency',
+    fieldName: key,
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Mean: ${getValueFormat('ns')(rec.avg_latency, 1)}
@@ -125,11 +117,7 @@ Max:  ${getValueFormat('ns')(rec.max_latency, 1)}`
   }
 }
 
-export function useExecCountColumn(
-  rows?: { exec_count?: number }[],
-  orderBy?: string,
-  desc?: boolean
-): IColumn {
+export function useExecCountColumn(rows?: { exec_count?: number }[]): IColumn {
   const capacity = rows ? max(rows.map((v) => v.exec_count)) ?? 0 : 0
   const key = 'exec_count'
   return {
@@ -139,8 +127,6 @@ export function useExecCountColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => (
       <Bar textWidth={70} value={rec.exec_count} capacity={capacity}>
         {getValueFormat('short')(rec.exec_count, 0, 1)}
@@ -150,9 +136,7 @@ export function useExecCountColumn(
 }
 
 export function useAvgMaxMemColumn(
-  rows?: { avg_mem?: number; max_mem?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { avg_mem?: number; max_mem?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.max_mem)) ?? 0 : 0
   const key = 'avg_mem'
@@ -163,8 +147,6 @@ export function useAvgMaxMemColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Mean: ${getValueFormat('bytes')(rec.avg_mem, 1)}
@@ -186,9 +168,7 @@ Max:  ${getValueFormat('bytes')(rec.max_mem, 1)}`
 }
 
 export function useErrorsWarningsColumn(
-  rows?: { sum_errors?: number; sum_warnings?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { sum_errors?: number; sum_warnings?: number }[]
 ): IColumn {
   const capacity = rows
     ? max(rows.map((v) => v.sum_errors! + v.sum_warnings!)) ?? 0
@@ -201,8 +181,6 @@ export function useErrorsWarningsColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Errors:   ${getValueFormat('short')(rec.sum_errors, 0)}
@@ -226,9 +204,7 @@ Warnings: ${getValueFormat('short')(rec.sum_warnings, 0)}`
 }
 
 export function useAvgParseLatencyColumn(
-  rows?: { avg_parse_latency?: number; max_parse_latency?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { avg_parse_latency?: number; max_parse_latency?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.max_parse_latency)) ?? 0 : 0
   const key = 'avg_parse_latency'
@@ -239,8 +215,6 @@ export function useAvgParseLatencyColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Mean: ${getValueFormat('ns')(rec.avg_parse_latency, 1)}
@@ -262,9 +236,7 @@ Max:  ${getValueFormat('ns')(rec.max_parse_latency, 1)}`
 }
 
 export function useAvgCompileLatencyColumn(
-  rows?: { avg_compile_latency?: number; max_compile_latency?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { avg_compile_latency?: number; max_compile_latency?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.max_compile_latency)) ?? 0 : 0
   const key = 'avg_compile_latency'
@@ -275,8 +247,6 @@ export function useAvgCompileLatencyColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Mean: ${getValueFormat('ns')(rec.avg_compile_latency, 1)}
@@ -297,9 +267,7 @@ Max:  ${getValueFormat('ns')(rec.max_compile_latency, 1)}`
   }
 }
 export function useAvgCoprColumn(
-  rows?: { avg_cop_process_time?: number; max_cop_process_time?: number }[],
-  orderBy?: string,
-  desc?: boolean
+  rows?: { avg_cop_process_time?: number; max_cop_process_time?: number }[]
 ): IColumn {
   const capacity = rows ? max(rows.map((v) => v.max_cop_process_time)) ?? 0 : 0
   const key = 'avg_cop_process_time'
@@ -310,8 +278,6 @@ export function useAvgCoprColumn(
     minWidth: 140,
     maxWidth: 200,
     isResizable: true,
-    isSorted: key === orderBy,
-    isSortedDescending: desc,
     onRender: (rec) => {
       const tooltipContent = `
 Mean: ${getValueFormat('ns')(rec.avg_cop_process_time, 1)}

--- a/ui/lib/apps/Statement/utils/useStatement.ts
+++ b/ui/lib/apps/Statement/utils/useStatement.ts
@@ -42,10 +42,10 @@ export default function useStatement(
   const [allSchemas, setAllSchemas] = useState<string[]>([])
   const [allStmtTypes, setAllStmtTypes] = useState<string[]>([])
 
-  const validTimeRange = useMemo(
-    () => calcValidStatementTimeRange(queryOptions.timeRange, allTimeRanges),
-    [queryOptions.timeRange, allTimeRanges]
-  )
+  const validTimeRange = useMemo(() => {
+    let curOptions = needSave ? savedQueryOptions : queryOptions
+    return calcValidStatementTimeRange(curOptions.timeRange, allTimeRanges)
+  }, [needSave, queryOptions, savedQueryOptions, allTimeRanges])
 
   const [loadingStatements, setLoadingStatements] = useState(true)
   const [statements, setStatements] = useState<StatementModel[]>([])

--- a/ui/lib/components/CardTableV2/index.tsx
+++ b/ui/lib/components/CardTableV2/index.tsx
@@ -5,7 +5,6 @@ import {
   DetailsListLayoutMode,
   SelectionMode,
   IDetailsListProps,
-  IColumn,
 } from 'office-ui-fabric-react/lib/DetailsList'
 import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList'
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
@@ -24,7 +23,6 @@ export interface ICardTableV2Props extends IDetailsListProps {
   // The keys of visible columns. If null, all columns will be shown.
   visibleColumnKeys?: { [key: string]: boolean }
   visibleItemsCount?: number
-  columnsWidth?: { [key: string]: number }
   // Event triggered when a row is clicked.
   onRowClicked?: (item: any, itemIndex: number) => void
 }
@@ -70,7 +68,6 @@ function CardTableV2(props: ICardTableV2Props) {
     cardNoMargin,
     visibleColumnKeys,
     visibleItemsCount,
-    columnsWidth,
     onRowClicked,
     columns,
     items,
@@ -79,30 +76,12 @@ function CardTableV2(props: ICardTableV2Props) {
 
   const renderClickableRow = useRenderClickableRow(onRowClicked)
 
-  const finalColumns = useMemo(() => {
-    let newColumns: IColumn[] = columns || []
-    if (visibleColumnKeys != null) {
-      newColumns = newColumns.filter((c) => visibleColumnKeys[c.key])
+  const filteredColumns = useMemo(() => {
+    if (columns == null || visibleColumnKeys == null) {
+      return columns
     }
-    // https://github.com/microsoft/fluentui/issues/9287
-    // ms doesn't support initial the columns width
-    if (columnsWidth != null) {
-      newColumns = newColumns.map((c) =>
-        columnsWidth[c.key]
-          ? {
-              ...c,
-              style: {
-                width: `${columnsWidth[c.key]}px`,
-              }, // doesn't work
-              currentWidth: columnsWidth[c.key], // doesn't work
-              calculatedWidth: columnsWidth[c.key], // doesn't work
-            }
-          : c
-      )
-    }
-    console.log(newColumns)
-    return newColumns
-  }, [columns, visibleColumnKeys, columnsWidth])
+    return columns.filter((c) => visibleColumnKeys[c.key])
+  }, [columns, visibleColumnKeys])
 
   const filteredItems = useMemo(() => {
     if (visibleItemsCount == null) {
@@ -129,7 +108,7 @@ function CardTableV2(props: ICardTableV2Props) {
           onRenderCheckbox={(props) => {
             return <Checkbox checked={props?.checked} />
           }}
-          columns={finalColumns}
+          columns={filteredColumns}
           items={filteredItems}
           enableShimmer={filteredItems.length > 0 ? false : loading}
           {...restProps}


### PR DESCRIPTION
resolve #447 

What did:

- Revert doesn't work code for persisting columns width
- Move all logic about sorting down to CardTableV2 to reduce duplicated logic
- Fix the wrong usage for hooks so now we can cache the tableColumns
- Fix the TimeRangeSelector doesn't work as expected