### PR TITLE
Support case-insensitive log searching

### DIFF
--- a/pkg/apiserver/logsearch/task.go
+++ b/pkg/apiserver/logsearch/task.go
@@ -187,7 +187,13 @@ func (t *Task) searchLog(client diagnosticspb.DiagnosticsClient, targetType diag
 	if t.model.Error != nil {
 		return
 	}
-	stream, err := client.SearchLog(t.ctx, t.taskGroup.model.SearchRequest.ConvertToPB(targetType))
+	req := t.taskGroup.model.SearchRequest.ConvertToPB(targetType)
+	patterns := make([]string, len(req.Patterns))
+	for i, p := range req.Patterns {
+		patterns[i] = "(?i)" + p
+	}
+	req.Patterns = patterns
+	stream, err := client.SearchLog(t.ctx, req)
 	if err != nil {
 		t.setError(err)
 		return


### PR DESCRIPTION
UCP #203 

## What?

Support Case Insensitive Log Searching

## How

By modifying regexp patterns with an `(?i)` ignore-case flag before sending `SearchLogRequest` to gRPC service.

## Compatibility

- [x] Golang `regexp` package, which uses [`re2`](https://github.com/google/re2/wiki/Syntax) underneath the hood, supports inline `i` flag
- [x] Rust `regex` crate also [supports `i` flag](https://docs.rs/regex/1.3.7/regex/#grouping-and-flags)

## Screenshot

![image](https://user-images.githubusercontent.com/14314532/81274792-5e928e80-9083-11ea-839b-9f03e2d82dff.png)
