### PR TITLE
avoid duplicate keys for table rows

### DIFF
--- a/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
+++ b/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
@@ -62,7 +62,9 @@ export default function SlowQueriesTable({
       columns={columns}
       items={slowQueries}
       onRowClicked={handleRowClick}
-      getKey={(row) => row?.digest}
+      getKey={(row, idx) =>
+        `${row?.digest}_${row?.timestamp}_${row?.txn_start_ts}_${idx}`
+      }
     />
   )
 }

--- a/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
+++ b/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
@@ -62,9 +62,7 @@ export default function SlowQueriesTable({
       columns={columns}
       items={slowQueries}
       onRowClicked={handleRowClick}
-      getKey={(row, idx) =>
-        `${row?.digest}_${row?.timestamp}_${row?.txn_start_ts}_${idx}`
-      }
+      getKey={(row) => `${row?.digest}_${row?.timestamp}`}
     />
   )
 }

--- a/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
+++ b/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
@@ -62,7 +62,7 @@ export default function SlowQueriesTable({
       columns={columns}
       items={slowQueries}
       onRowClicked={handleRowClick}
-      getKey={(row) => `${row?.digest}_${row?.timestamp}`}
+      getKey={(row) => row && `${row.digest}_${row.timestamp}`}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -66,9 +66,7 @@ export default function StatementsTable({
       columns={columns}
       items={statements}
       onRowClicked={handleRowClick}
-      getKey={(row, idx) =>
-        `${row?.digest}_${row?.sum_latency}_${row?.max_latency}_${idx}`
-      }
+      getKey={(row) => `${row?.digest}_${row?.schema_name}`}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -66,7 +66,7 @@ export default function StatementsTable({
       columns={columns}
       items={statements}
       onRowClicked={handleRowClick}
-      getKey={(row) => `${row?.digest}_${row?.schema_name}`}
+      getKey={(row) => row && `${row.digest}_${row.schema_name}`}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -66,7 +66,9 @@ export default function StatementsTable({
       columns={columns}
       items={statements}
       onRowClicked={handleRowClick}
-      getKey={(row) => row?.digest}
+      getKey={(row, idx) =>
+        `${row?.digest}_${row?.sum_latency}_${row?.max_latency}_${idx}`
+      }
     />
   )
 }


### PR DESCRIPTION
Hi @breeswish , I forgot the slow queries may have the same digest, using `getKey={row => row?.digest}` will cause duplicate keys for slow query table, so I add more fields to avoid this. Although `row?.digest` works fine for statement table, I add more as well just in case.

Or we can wait for your PR which mentioned in https://github.com/pingcap-incubator/tidb-dashboard/pull/454#issuecomment-625242923 if it relates to this.