### PR TITLE
Refine instance host tables

### DIFF
--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -7,7 +7,7 @@ import { WarningOutlined } from '@ant-design/icons'
 import { getValueFormat } from '@baurine/grafana-value-formats'
 
 import client from '@lib/client'
-import { Bar, CardTableV2 } from '@lib/components'
+import { Bar, CardTableV2, Pre } from '@lib/components'
 import { dummyColumn } from '@lib/utils/tableColumns'
 import { useClientRequest } from '@lib/utils/useClientRequest'
 
@@ -30,8 +30,8 @@ export default function HostTable() {
     {
       name: t('cluster_info.list.host_table.columns.ip'),
       key: 'ip',
-      minWidth: 150,
-      maxWidth: 200,
+      minWidth: 100,
+      maxWidth: 150,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ ip, unavailable }) => {
@@ -72,14 +72,11 @@ export default function HostTable() {
         }
         const { system, idle } = cpu_usage
         const user = 1 - system - idle
-        const title = (
-          <>
-            <div>User: {getValueFormat('percentunit')(user)}</div>
-            <div>System: {getValueFormat('percentunit')(system)}</div>
-          </>
-        )
+        const tooltipContent = `
+User:   ${getValueFormat('percentunit')(user)}
+System: ${getValueFormat('percentunit')(system)}`
         return (
-          <Tooltip title={title}>
+          <Tooltip title={<Pre>{tooltipContent.trim()}</Pre>}>
             <Bar value={[user, system]} colors={[null, red[4]]} capacity={1} />
           </Tooltip>
         )
@@ -159,9 +156,10 @@ export default function HostTable() {
           if (serverTotal.tiflash > 0) {
             serverInfos.push(`${serverTotal.tiflash} TiFlash`)
           }
-          return `${serverInfos.join(
+          const content = `${serverInfos.join(
             ','
           )}: ${partition.partition.fstype.toUpperCase()} ${currentMountPoint}`
+          return <Tooltip title={content}>{content as any}</Tooltip>
         })
       },
     },

--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -159,7 +159,11 @@ System: ${getValueFormat('percentunit')(system)}`
           const content = `${serverInfos.join(
             ','
           )}: ${partition.partition.fstype.toUpperCase()} ${currentMountPoint}`
-          return <Tooltip title={content}>{content as any}</Tooltip>
+          return (
+            <Tooltip title={content}>
+              <span>{content}</span>
+            </Tooltip>
+          )
         })
       },
     },

--- a/ui/lib/apps/ClusterInfo/components/InstanceTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/InstanceTable.tsx
@@ -13,6 +13,7 @@ import {
 import client from '@lib/client'
 import { CardTableV2 } from '@lib/components'
 import DateTime from '@lib/components/DateTime'
+import { dummyColumn } from '@lib/utils/tableColumns'
 import { useClientRequest } from '@lib/utils/useClientRequest'
 
 function useStatusColumnRender(handleHideTiDB) {
@@ -153,21 +154,18 @@ export default function ListPage() {
       name: t('cluster_info.list.instance_table.columns.node'),
       key: 'node',
       minWidth: 100,
-      maxWidth: 200,
+      maxWidth: 160,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
-      onRender: (node) => (
-        <Tooltip title={`${node.ip}:${node.port}`}>
-          <span>
-            {node.ip}:{node.port}
-          </span>
-        </Tooltip>
-      ),
+      onRender: ({ ip, port }) => {
+        const fullName = `${ip}:${port}`
+        return <Tooltip title={fullName}>{fullName as any}</Tooltip>
+      },
     },
     {
       name: t('cluster_info.list.instance_table.columns.status'),
       key: 'status',
-      minWidth: 100,
+      minWidth: 80,
       maxWidth: 100,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
@@ -190,29 +188,37 @@ export default function ListPage() {
       name: t('cluster_info.list.instance_table.columns.version'),
       fieldName: 'version',
       key: 'version',
-      minWidth: 150,
-      maxWidth: 300,
+      minWidth: 100,
+      maxWidth: 250,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
+      onRender: ({ version }) => <Tooltip title={version}>{version}</Tooltip>,
     },
     {
       name: t('cluster_info.list.instance_table.columns.deploy_path'),
       fieldName: 'deploy_path',
       key: 'deploy_path',
-      minWidth: 150,
-      maxWidth: 300,
+      minWidth: 100,
+      maxWidth: 200,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
+      onRender: ({ deploy_path }) => (
+        <Tooltip title={deploy_path}>{deploy_path}</Tooltip>
+      ),
     },
     {
       name: t('cluster_info.list.instance_table.columns.git_hash'),
       fieldName: 'git_hash',
       key: 'git_hash',
-      minWidth: 150,
-      maxWidth: 300,
+      minWidth: 100,
+      maxWidth: 150,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
+      onRender: ({ git_hash }) => (
+        <Tooltip title={git_hash}>{git_hash}</Tooltip>
+      ),
     },
+    dummyColumn(),
   ]
 
   return (

--- a/ui/lib/apps/ClusterInfo/components/InstanceTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/InstanceTable.tsx
@@ -159,7 +159,11 @@ export default function ListPage() {
       columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ ip, port }) => {
         const fullName = `${ip}:${port}`
-        return <Tooltip title={fullName}>{fullName as any}</Tooltip>
+        return (
+          <Tooltip title={fullName}>
+            <span>{fullName}</span>
+          </Tooltip>
+        )
       },
     },
     {
@@ -192,7 +196,11 @@ export default function ListPage() {
       maxWidth: 250,
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
-      onRender: ({ version }) => <Tooltip title={version}>{version}</Tooltip>,
+      onRender: ({ version }) => (
+        <Tooltip title={version}>
+          <span>{version}</span>
+        </Tooltip>
+      ),
     },
     {
       name: t('cluster_info.list.instance_table.columns.deploy_path'),
@@ -203,7 +211,9 @@ export default function ListPage() {
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ deploy_path }) => (
-        <Tooltip title={deploy_path}>{deploy_path}</Tooltip>
+        <Tooltip title={deploy_path}>
+          <span>{deploy_path}</span>
+        </Tooltip>
       ),
     },
     {
@@ -215,7 +225,9 @@ export default function ListPage() {
       isResizable: true,
       columnActionsMode: ColumnActionsMode.disabled,
       onRender: ({ git_hash }) => (
-        <Tooltip title={git_hash}>{git_hash}</Tooltip>
+        <Tooltip title={git_hash}>
+          <span>{git_hash}</span>
+        </Tooltip>
       ),
     },
     dummyColumn(),


### PR DESCRIPTION
What did:

- Refine InstanceTable, add tooltip for version/deploy_path/git_hash columns, add dummyColumn
- Refine HostTable, add tooltip for disk column

Before:

![企业微信20200511064550](https://user-images.githubusercontent.com/1284531/81553618-ffe94f80-93b7-11ea-8b65-f5ed004b2aaa.png)

After:

![企业微信20200511062810](https://user-images.githubusercontent.com/1284531/81553635-07a8f400-93b8-11ea-9184-c41a6d640b5e.png)
