### PR TITLE
log_search: stop polling tasks status when all tasks finished

### DIFF
--- a/ui/lib/apps/SearchLogs/LogSearchingDetail.tsx
+++ b/ui/lib/apps/SearchLogs/LogSearchingDetail.tsx
@@ -28,9 +28,9 @@ export default function LogSearchingDetail() {
       return false
     }
     if (data.tasks.some((task) => task.state === TaskState.Running)) {
-      return true
+      return false
     }
-    return false
+    return true
   }
 
   const { data } = useClientRequestWithPolling(


### PR DESCRIPTION
Fix the bug when all log search tasks finished, polling task status should stop.