### PR TITLE
profiling: support view and download a single profiling

### DIFF
--- a/pkg/apiserver/profiling/router.go
+++ b/pkg/apiserver/profiling/router.go
@@ -35,12 +35,14 @@ func Register(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 	endpoint.GET("/group/detail/:groupId", auth.MWAuthRequired(), s.getGroupDetail)
 	endpoint.POST("/group/cancel/:groupId", auth.MWAuthRequired(), s.handleCancelGroup)
 	endpoint.DELETE("/group/delete/:groupId", auth.MWAuthRequired(), s.deleteGroup)
-	endpoint.GET("/group/download/acquire_token", auth.MWAuthRequired(), s.getGroupDownloadToken)
+
+	endpoint.GET("/action_token", auth.MWAuthRequired(), s.getActionToken)
 	endpoint.GET("/group/download", s.downloadGroup)
-	endpoint.GET("/single/download/acquire_token", auth.MWAuthRequired(), s.getSingleDownloadToken)
 	endpoint.GET("/single/download", s.downloadSingle)
-	endpoint.GET("/config", s.getDynamicConfig)
-	endpoint.PUT("/config", s.setDynamicConfig)
+	endpoint.GET("/single/view", s.viewSingle)
+
+	endpoint.GET("/config", auth.MWAuthRequired(), s.getDynamicConfig)
+	endpoint.PUT("/config", auth.MWAuthRequired(), s.setDynamicConfig)
 }
 
 // @ID startProfiling
@@ -183,19 +185,21 @@ func (s *Service) handleCancelGroup(c *gin.Context) {
 	c.JSON(http.StatusOK, utils.APIEmptyResponse{})
 }
 
-// @ID getProfilingGroupDownloadToken
-// @Summary Get download token for group download
-// @Description Get download token with a given group ID
+// @ID getActionToken
+// @Summary Get action token for download or view
+// @Description Get token with a given group ID or task ID and action type
 // @Produce plain
-// @Param id query string false "group ID"
+// @Param id query string false "group or task ID"
+// @Param action query string false "action"
 // @Security JwtAuth
 // @Success 200 {string} string
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /profiling/group/download/acquire_token [get]
-func (s *Service) getGroupDownloadToken(c *gin.Context) {
+// @Router /profiling/action_token [get]
+func (s *Service) getActionToken(c *gin.Context) {
 	id := c.Query("id")
-	token, err := utils.NewJWTString("profiling/group_download", id)
+	action := c.Query("action") // group_download, single_download, single_view
+	token, err := utils.NewJWTString("profiling/"+action, id)
 	if err != nil {
 		c.Status(http.StatusBadRequest)
 		_ = c.Error(utils.ErrInvalidRequest.WrapWithNoMessage(err))
@@ -260,27 +264,6 @@ func (s *Service) downloadGroup(c *gin.Context) {
 	c.FileAttachment(temp.Name(), fileName)
 }
 
-// @ID getProfilingSingleDownloadToken
-// @Summary Get download token for single download
-// @Description Get download token with a given task ID
-// @Produce plain
-// @Param id query string false "task ID"
-// @Security JwtAuth
-// @Success 200 {string} string
-// @Failure 400 {object} utils.APIError
-// @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /profiling/single/download/acquire_token [get]
-func (s *Service) getSingleDownloadToken(c *gin.Context) {
-	id := c.Query("id")
-	token, err := utils.NewJWTString("profiling/single_download", id)
-	if err != nil {
-		c.Status(http.StatusBadRequest)
-		_ = c.Error(utils.ErrInvalidRequest.WrapWithNoMessage(err))
-		return
-	}
-	c.String(http.StatusOK, token)
-}
-
 // @ID downloadProfilingSingle
 // @Summary Download the result of a task
 // @Description Download the finished profiling result of a task
@@ -331,6 +314,47 @@ func (s *Service) downloadSingle(c *gin.Context) {
 
 	fileName := fmt.Sprintf("profiling_%d.tar.gz", taskID)
 	c.FileAttachment(temp.Name(), fileName)
+}
+
+// @ID viewProfilingSingle
+// @Summary View the result of a task
+// @Description View the finished profiling result of a task
+// @Produce html
+// @Param token query string true "download token"
+// @Security JwtAuth
+// @Failure 400 {object} utils.APIError
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
+// @Failure 500 {object} utils.APIError
+// @Router /profiling/single/view [get]
+func (s *Service) viewSingle(c *gin.Context) {
+	token := c.Query("token")
+	str, err := utils.ParseJWTString("profiling/single_view", token)
+	if err != nil {
+		c.Status(http.StatusUnauthorized)
+		_ = c.Error(utils.ErrInvalidRequest.New(err.Error()))
+		return
+	}
+	taskID, err := strconv.Atoi(str)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		_ = c.Error(err)
+		return
+	}
+	task := TaskModel{}
+	err = s.db.Where("id = ? AND state = ?", taskID, TaskStateFinish).First(&task).Error
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		_ = c.Error(err)
+		return
+	}
+
+	content, err := ioutil.ReadFile(task.FilePath)
+	if err != nil {
+		c.Status(http.StatusInternalServerError)
+		_ = c.Error(err)
+		return
+	}
+	c.Data(http.StatusOK, "image/svg+xml", content)
 }
 
 // @ID deleteProfilingGroup

--- a/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
+++ b/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
@@ -8,6 +8,7 @@ import client, { ProfilingTaskModel } from '@lib/client'
 import { CardTableV2, Head } from '@lib/components'
 import { useClientRequestWithPolling } from '@lib/utils/useClientRequest'
 import { dummyColumn } from '@lib/utils/tableColumns'
+import { ColumnActionsMode } from 'office-ui-fabric-react/lib/DetailsList'
 
 function mapData(data) {
   if (!data) {
@@ -74,7 +75,10 @@ export default function Page() {
     if (!token) {
       return
     }
-    window.open(`${client.getBasePath()}/profiling/single/view?token=${token}`)
+    window.open(
+      `${client.getBasePath()}/profiling/single/view?token=${token}`,
+      '_blank'
+    )
   }, [])
 
   const columns = useMemo(
@@ -85,6 +89,7 @@ export default function Page() {
         minWidth: 150,
         maxWidth: 400,
         isResizable: true,
+        columnActionsMode: ColumnActionsMode.disabled, // will move to CardTableV2
         onRender: (record) => record.target.display_name,
       },
       {
@@ -93,6 +98,7 @@ export default function Page() {
         minWidth: 100,
         maxWidth: 150,
         isResizable: true,
+        columnActionsMode: ColumnActionsMode.disabled,
         onRender: (record) => record.target.kind,
       },
       {
@@ -101,6 +107,7 @@ export default function Page() {
         minWidth: 150,
         maxWidth: 200,
         isResizable: true,
+        columnActionsMode: ColumnActionsMode.disabled,
         onRender: (record) => {
           if (record.state === 1) {
             return (
@@ -125,18 +132,23 @@ export default function Page() {
         },
       },
       {
-        name: 'Action',
+        name: t('instance_profiling.common.actions.action'),
         key: 'action',
         minWidth: 100,
         maxWidth: 200,
         isResizable: true,
+        columnActionsMode: ColumnActionsMode.disabled,
         onRender: (record: ProfilingTaskModel) => {
           if (record.state === 2) {
             return (
               <div>
-                <a onClick={() => handleViewSingle(record.id)}>View</a>
+                <a onClick={() => handleViewSingle(record.id)}>
+                  {t('instance_profiling.common.actions.view')}
+                </a>
                 <Divider type="vertical"></Divider>
-                <a onClick={() => handleDownloadSingle(record.id)}>Download</a>
+                <a onClick={() => handleDownloadSingle(record.id)}>
+                  {t('instance_profiling.common.actions.download')}
+                </a>
               </div>
             )
           }

--- a/ui/lib/apps/InstanceProfiling/translations/en.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/en.yaml
@@ -34,8 +34,3 @@ instance_profiling:
         status: Status
       status:
         finished: Finished
-  common:
-    actions:
-      action: Action
-      view: View
-      download: Download

--- a/ui/lib/apps/InstanceProfiling/translations/en.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/en.yaml
@@ -16,7 +16,6 @@ instance_profiling:
         start_at: Start At
         duration: Duration (sec)
         status: Status
-        action: Action
       status:
         running: Running
         finished: Finished
@@ -35,3 +34,8 @@ instance_profiling:
         status: Status
       status:
         finished: Finished
+  common:
+    actions:
+      action: Action
+      view: View
+      download: Download

--- a/ui/lib/apps/InstanceProfiling/translations/zh-CN.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/zh-CN.yaml
@@ -16,7 +16,6 @@ instance_profiling:
         start_at: 开始时间
         duration: 时长 (秒)
         status: 状态
-        action: 操作
       status:
         running: 分析中
         finished: 完成
@@ -35,3 +34,8 @@ instance_profiling:
         status: 状态
       status:
         finished: 完成
+  common:
+    actions:
+      action: 操作
+      view: 查看
+      download: 下载

--- a/ui/lib/apps/InstanceProfiling/translations/zh-CN.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/zh-CN.yaml
@@ -34,8 +34,3 @@ instance_profiling:
         status: 状态
       status:
         finished: 完成
-  common:
-    actions:
-      action: 操作
-      view: 查看
-      download: 下载


### PR DESCRIPTION
What did:

- Support view single profiling online
- Support download single profiling file
- Unify the get action token handler

Screenshots:

![46](https://user-images.githubusercontent.com/1284531/81650423-70e64100-9464-11ea-88ab-6fe0a40850d6.gif)

