### PR TITLE
Fix sticky table header can't scroll with its body in horizontal direction

### DIFF
--- a/ui/lib/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/lib/apps/SlowQuery/pages/List/index.tsx
@@ -16,7 +16,6 @@ import {
 import client from '@lib/client'
 import SlowQueriesTable from '../../components/SlowQueriesTable'
 import useSlowQuery from '../../utils/useSlowQuery'
-import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
 
 const { Option } = Select
 const { Search } = Input

--- a/ui/lib/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/lib/apps/SlowQuery/pages/List/index.tsx
@@ -67,98 +67,97 @@ function List() {
   }, [])
 
   return (
-    <ScrollablePane style={{ height: '100vh' }}>
-      <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced>
-        <Card>
-          <Toolbar>
-            <Space>
-              <TimeRangeSelector
-                value={queryOptions.timeRange}
-                onChange={(timeRange) =>
-                  setQueryOptions({ ...queryOptions, timeRange })
-                }
-              />
-              <Select
-                value={queryOptions.schemas}
-                mode="multiple"
-                allowClear
-                placeholder={t(
-                  'statement.pages.overview.toolbar.select_schemas'
-                )}
-                style={{ minWidth: 200 }}
-                onChange={(schemas) =>
-                  setQueryOptions({ ...queryOptions, schemas })
-                }
-              >
-                {allSchemas.map((item) => (
-                  <Option value={item} key={item}>
-                    {item}
-                  </Option>
-                ))}
-              </Select>
-              <Search
-                defaultValue={queryOptions.searchText}
-                onSearch={(searchText) =>
-                  setQueryOptions({ ...queryOptions, searchText })
-                }
-              />
-              <Select
-                value={queryOptions.limit}
-                style={{ width: 150 }}
-                onChange={(limit) =>
-                  setQueryOptions({ ...queryOptions, limit })
-                }
-              >
-                {LIMITS.map((item) => (
-                  <Option value={item} key={item}>
-                    Limit {item}
-                  </Option>
-                ))}
-              </Select>
-            </Space>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Card>
+        <Toolbar>
+          <Space>
+            <TimeRangeSelector
+              value={queryOptions.timeRange}
+              onChange={(timeRange) =>
+                setQueryOptions({ ...queryOptions, timeRange })
+              }
+            />
+            <Select
+              value={queryOptions.schemas}
+              mode="multiple"
+              allowClear
+              placeholder={t('statement.pages.overview.toolbar.select_schemas')}
+              style={{ minWidth: 200 }}
+              onChange={(schemas) =>
+                setQueryOptions({ ...queryOptions, schemas })
+              }
+            >
+              {allSchemas.map((item) => (
+                <Option value={item} key={item}>
+                  {item}
+                </Option>
+              ))}
+            </Select>
+            <Search
+              defaultValue={queryOptions.searchText}
+              onSearch={(searchText) =>
+                setQueryOptions({ ...queryOptions, searchText })
+              }
+            />
+            <Select
+              value={queryOptions.limit}
+              style={{ width: 150 }}
+              onChange={(limit) => setQueryOptions({ ...queryOptions, limit })}
+            >
+              {LIMITS.map((item) => (
+                <Option value={item} key={item}>
+                  Limit {item}
+                </Option>
+              ))}
+            </Select>
+          </Space>
 
-            <Space>
-              {columns.length > 0 && (
-                <ColumnsSelector
-                  columns={columns}
-                  visibleColumnKeys={visibleColumnKeys}
-                  resetColumnKeys={defSlowQueryColumnKeys}
-                  onChange={setVisibleColumnKeys}
-                  foot={
-                    <Checkbox
-                      checked={showFullSQL}
-                      onChange={(e) => setShowFullSQL(e.target.checked)}
-                    >
-                      {t(
-                        'statement.pages.overview.toolbar.select_columns.show_full_sql'
-                      )}
-                    </Checkbox>
-                  }
-                />
+          <Space>
+            {columns.length > 0 && (
+              <ColumnsSelector
+                columns={columns}
+                visibleColumnKeys={visibleColumnKeys}
+                resetColumnKeys={defSlowQueryColumnKeys}
+                onChange={setVisibleColumnKeys}
+                foot={
+                  <Checkbox
+                    checked={showFullSQL}
+                    onChange={(e) => setShowFullSQL(e.target.checked)}
+                  >
+                    {t(
+                      'statement.pages.overview.toolbar.select_columns.show_full_sql'
+                    )}
+                  </Checkbox>
+                }
+              />
+            )}
+            <Tooltip title={t('statement.pages.overview.toolbar.refresh')}>
+              {loadingSlowQueries ? (
+                <LoadingOutlined />
+              ) : (
+                <ReloadOutlined onClick={refresh} />
               )}
-              <Tooltip title={t('statement.pages.overview.toolbar.refresh')}>
-                {loadingSlowQueries ? (
-                  <LoadingOutlined />
-                ) : (
-                  <ReloadOutlined onClick={refresh} />
-                )}
-              </Tooltip>
-            </Space>
-          </Toolbar>
-        </Card>
-      </Sticky>
+            </Tooltip>
+          </Space>
+        </Toolbar>
+      </Card>
 
-      <SlowQueriesTable
-        loading={loadingSlowQueries}
-        slowQueries={slowQueries}
-        orderBy={orderOptions.orderBy}
-        desc={orderOptions.desc}
-        showFullSQL={showFullSQL}
-        visibleColumnKeys={visibleColumnKeys}
-        onGetColumns={setColumns}
-        onChangeOrder={changeOrder}
-      />
-    </ScrollablePane>
+      <div style={{ height: '100%', position: 'relative' }}>
+        <ScrollablePane>
+          <SlowQueriesTable
+            cardNoMarginTop
+            loading={loadingSlowQueries}
+            slowQueries={slowQueries}
+            orderBy={orderOptions.orderBy}
+            desc={orderOptions.desc}
+            showFullSQL={showFullSQL}
+            visibleColumnKeys={visibleColumnKeys}
+            onGetColumns={setColumns}
+            onChangeOrder={changeOrder}
+          />
+        </ScrollablePane>
+      </div>
+    </div>
   )
 }
 

--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -14,7 +14,6 @@ import { StatementsTable } from '../../components'
 import StatementSettingForm from './StatementSettingForm'
 import TimeRangeSelector from './TimeRangeSelector'
 import useStatement from '../../utils/useStatement'
-import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
 
 const { Option } = Select
 

--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -61,111 +61,112 @@ export default function StatementsOverview() {
   )
 
   return (
-    <ScrollablePane style={{ height: '100vh' }}>
-      <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced>
-        <Card>
-          <Toolbar>
-            <Space>
-              <TimeRangeSelector
-                value={queryOptions.timeRange}
-                timeRanges={allTimeRanges}
-                onChange={(timeRange) =>
-                  setQueryOptions({
-                    ...queryOptions,
-                    timeRange,
-                  })
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Card>
+        <Toolbar>
+          <Space>
+            <TimeRangeSelector
+              value={queryOptions.timeRange}
+              timeRanges={allTimeRanges}
+              onChange={(timeRange) =>
+                setQueryOptions({
+                  ...queryOptions,
+                  timeRange,
+                })
+              }
+            />
+            <Select
+              value={queryOptions.schemas}
+              mode="multiple"
+              allowClear
+              placeholder={t('statement.pages.overview.toolbar.select_schemas')}
+              style={{ minWidth: 200 }}
+              onChange={(schemas) =>
+                setQueryOptions({
+                  ...queryOptions,
+                  schemas,
+                })
+              }
+            >
+              {allSchemas.map((item) => (
+                <Option value={item} key={item}>
+                  {item}
+                </Option>
+              ))}
+            </Select>
+            <Select
+              value={queryOptions.stmtTypes}
+              mode="multiple"
+              allowClear
+              placeholder={t(
+                'statement.pages.overview.toolbar.select_stmt_types'
+              )}
+              style={{ minWidth: 160 }}
+              onChange={(stmtTypes) =>
+                setQueryOptions({
+                  ...queryOptions,
+                  stmtTypes,
+                })
+              }
+            >
+              {allStmtTypes.map((item) => (
+                <Option value={item} key={item}>
+                  {item.toUpperCase()}
+                </Option>
+              ))}
+            </Select>
+          </Space>
+
+          <Space>
+            {columns.length > 0 && (
+              <ColumnsSelector
+                columns={columns}
+                visibleColumnKeys={visibleColumnKeys}
+                resetColumnKeys={defColumnKeys}
+                onChange={setVisibleColumnKeys}
+                foot={
+                  <Checkbox
+                    checked={showFullSQL}
+                    onChange={(e) => setShowFullSQL(e.target.checked)}
+                  >
+                    {t(
+                      'statement.pages.overview.toolbar.select_columns.show_full_sql'
+                    )}
+                  </Checkbox>
                 }
               />
-              <Select
-                value={queryOptions.schemas}
-                mode="multiple"
-                allowClear
-                placeholder={t(
-                  'statement.pages.overview.toolbar.select_schemas'
-                )}
-                style={{ minWidth: 200 }}
-                onChange={(schemas) =>
-                  setQueryOptions({
-                    ...queryOptions,
-                    schemas,
-                  })
-                }
-              >
-                {allSchemas.map((item) => (
-                  <Option value={item} key={item}>
-                    {item}
-                  </Option>
-                ))}
-              </Select>
-              <Select
-                value={queryOptions.stmtTypes}
-                mode="multiple"
-                allowClear
-                placeholder={t(
-                  'statement.pages.overview.toolbar.select_stmt_types'
-                )}
-                style={{ minWidth: 160 }}
-                onChange={(stmtTypes) =>
-                  setQueryOptions({
-                    ...queryOptions,
-                    stmtTypes,
-                  })
-                }
-              >
-                {allStmtTypes.map((item) => (
-                  <Option value={item} key={item}>
-                    {item.toUpperCase()}
-                  </Option>
-                ))}
-              </Select>
-            </Space>
-
-            <Space>
-              {columns.length > 0 && (
-                <ColumnsSelector
-                  columns={columns}
-                  visibleColumnKeys={visibleColumnKeys}
-                  resetColumnKeys={defColumnKeys}
-                  onChange={setVisibleColumnKeys}
-                  foot={
-                    <Checkbox
-                      checked={showFullSQL}
-                      onChange={(e) => setShowFullSQL(e.target.checked)}
-                    >
-                      {t(
-                        'statement.pages.overview.toolbar.select_columns.show_full_sql'
-                      )}
-                    </Checkbox>
-                  }
-                />
+            )}
+            <Tooltip title={t('statement.settings.title')}>
+              <SettingOutlined onClick={() => setShowSettings(true)} />
+            </Tooltip>
+            <Tooltip title={t('statement.pages.overview.toolbar.refresh')}>
+              {loadingStatements ? (
+                <LoadingOutlined />
+              ) : (
+                <ReloadOutlined onClick={refresh} />
               )}
-              <Tooltip title={t('statement.settings.title')}>
-                <SettingOutlined onClick={() => setShowSettings(true)} />
-              </Tooltip>
-              <Tooltip title={t('statement.pages.overview.toolbar.refresh')}>
-                {loadingStatements ? (
-                  <LoadingOutlined />
-                ) : (
-                  <ReloadOutlined onClick={refresh} />
-                )}
-              </Tooltip>
-            </Space>
-          </Toolbar>
-        </Card>
-      </Sticky>
+            </Tooltip>
+          </Space>
+        </Toolbar>
+      </Card>
 
       {enable ? (
-        <StatementsTable
-          loading={loadingStatements}
-          statements={statements}
-          timeRange={validTimeRange}
-          orderBy={orderOptions.orderBy}
-          desc={orderOptions.desc}
-          showFullSQL={showFullSQL}
-          visibleColumnKeys={visibleColumnKeys}
-          onGetColumns={setColumns}
-          onChangeOrder={changeOrder}
-        />
+        <div style={{ height: '100%', position: 'relative' }}>
+          <ScrollablePane>
+            <StatementsTable
+              cardNoMarginTop
+              loading={loadingStatements}
+              statements={statements}
+              timeRange={validTimeRange}
+              orderBy={orderOptions.orderBy}
+              desc={orderOptions.desc}
+              showFullSQL={showFullSQL}
+              visibleColumnKeys={visibleColumnKeys}
+              onGetColumns={setColumns}
+              onChangeOrder={changeOrder}
+            />
+          </ScrollablePane>
+        </div>
       ) : (
         <Result
           title={t('statement.settings.disabled_result.title')}
@@ -191,6 +192,6 @@ export default function StatementsOverview() {
           onConfigUpdated={refresh}
         />
       </Drawer>
-    </ScrollablePane>
+    </div>
   )
 }

--- a/ui/lib/components/Card/index.module.less
+++ b/ui/lib/components/Card/index.module.less
@@ -16,6 +16,10 @@
     margin: 0;
   }
 
+  &.noMarginTop {
+    margin-top: 0;
+  }
+
   &.noMarginLeft {
     margin-left: 0;
   }

--- a/ui/lib/components/Card/index.tsx
+++ b/ui/lib/components/Card/index.tsx
@@ -8,6 +8,7 @@ export interface ICardProps
   subTitle?: ReactNode
   extra?: ReactNode
   noMargin?: boolean
+  noMarginTop?: boolean
   noMarginLeft?: boolean
   noMarginRight?: boolean
 }
@@ -18,6 +19,7 @@ export default function Card({
   extra,
   className,
   noMargin,
+  noMarginTop,
   noMarginLeft,
   noMarginRight,
   children,
@@ -28,6 +30,7 @@ export default function Card({
       <div
         className={cx(styles.cardInner, {
           [styles.noMargin]: noMargin,
+          [styles.noMarginTop]: noMarginTop,
           [styles.noMarginLeft]: noMarginLeft,
           [styles.noMarginRight]: noMarginRight,
           [styles.hasTitle]: title || subTitle || extra,

--- a/ui/lib/components/CardTableV2/index.tsx
+++ b/ui/lib/components/CardTableV2/index.tsx
@@ -6,6 +6,7 @@ import {
   IColumn,
   IDetailsListProps,
   SelectionMode,
+  ConstrainMode,
 } from 'office-ui-fabric-react/lib/DetailsList'
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
 import React, { useCallback, useMemo } from 'react'
@@ -43,6 +44,7 @@ export interface ICardTableV2Props extends IDetailsListProps {
   loading?: boolean
   cardExtra?: React.ReactNode
   cardNoMargin?: boolean
+  cardNoMarginTop?: boolean
 
   // The keys of visible columns. If null, all columns will be shown.
   visibleColumnKeys?: { [key: string]: boolean }
@@ -100,6 +102,7 @@ function CardTableV2(props: ICardTableV2Props) {
     loading = false,
     cardExtra,
     cardNoMargin,
+    cardNoMarginTop,
     visibleColumnKeys,
     visibleItemsCount,
     orderBy,
@@ -166,12 +169,14 @@ function CardTableV2(props: ICardTableV2Props) {
       style={style}
       className={cx(styles.cardTable, className)}
       noMargin={cardNoMargin}
+      noMarginTop={cardNoMarginTop}
       extra={cardExtra}
     >
       <AnimatedSkeleton showSkeleton={items.length === 0 && loading}>
         <div className={styles.cardTableContent}>
           <MemoDetailsList
             selectionMode={SelectionMode.none}
+            constrainMode={ConstrainMode.unconstrained}
             layoutMode={DetailsListLayoutMode.justified}
             onRenderDetailsHeader={renderStickyHeader}
             onRenderRow={onRowClicked ? renderClickableRow : undefined}


### PR DESCRIPTION
fix #462 

What did:

- Fix the bug that sticky table header can't scroll with the body in the horizontal direction

The original situation:

![51_origin](https://user-images.githubusercontent.com/1284531/81779388-31ccf400-9527-11ea-9d37-d863393a416e.gif)

According to the issue: https://github.com/microsoft/fluentui/issues/7742 , the easiest way is to just set `constrainMode={ConstrainMode.unconstrained}` for DetailsList. This makes the sticky table header scrolls with its body but makes the sticky toolbar scrolls as well (same as the official demo), I don't think it is expected.

![48_solution_1](https://user-images.githubusercontent.com/1284531/81779654-bb7cc180-9527-11ea-896a-2fe5dae853f5.gif)

So I only wrap the table instead of the root container by `<ScrollablePane>`.

![49_solution_2](https://user-images.githubusercontent.com/1284531/81779765-f7178b80-9527-11ea-81b5-c5c175a100d1.gif)

But the margin collapse doesn't work anymore, it makes the sticky table header jumping when it switches between sticky or not.

Adding another new props `noMarginTop` to remove the additional margin-top, maybe not very elegant, doesn't know whether it has some better ideas. (still a little jumping but much better than above)

Final effect:

![52_solution_final](https://user-images.githubusercontent.com/1284531/81780094-82911c80-9528-11ea-862b-cc04d3f5a3ec.gif)


