### PR TITLE
ui: Fix others table layout when small screen

### DIFF
--- a/ui/lib/apps/Diagnose/components/DiagnoseGenerator.tsx
+++ b/ui/lib/apps/Diagnose/components/DiagnoseGenerator.tsx
@@ -57,7 +57,7 @@ export default function DiagnoseGenerator() {
   const handleFinish = useFinishHandler(navigate)
 
   return (
-    <ScrollablePane style={{ height: '100vh' }}>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <Card title={t('diagnose.generate.title')}>
         <Form
           layout="inline"
@@ -149,7 +149,12 @@ export default function DiagnoseGenerator() {
           </Form.Item>
         </Form>
       </Card>
-      <DiagnoseHistory />
-    </ScrollablePane>
+
+      <div style={{ height: '100%', position: 'relative' }}>
+        <ScrollablePane>
+          <DiagnoseHistory />
+        </ScrollablePane>
+      </div>
+    </div>
   )
 }

--- a/ui/lib/apps/Diagnose/components/DiagnoseHistory.tsx
+++ b/ui/lib/apps/Diagnose/components/DiagnoseHistory.tsx
@@ -109,6 +109,7 @@ export default function DiagnoseHistory() {
 
   return (
     <CardTableV2
+      cardNoMarginTop
       loading={isLoading}
       items={data || []}
       columns={columns}

--- a/ui/lib/apps/InstanceProfiling/pages/List.tsx
+++ b/ui/lib/apps/InstanceProfiling/pages/List.tsx
@@ -202,7 +202,7 @@ export default function Page() {
   ]
 
   return (
-    <ScrollablePane style={{ height: '100vh' }}>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <Card title={t('instance_profiling.list.control_form.title')}>
         <Form layout="inline">
           <Form.Item
@@ -245,12 +245,18 @@ export default function Page() {
           </Form.Item>
         </Form>
       </Card>
-      <CardTableV2
-        loading={listLoading}
-        items={historyTable || []}
-        columns={historyTableColumns}
-        onRowClicked={handleRowClick}
-      />
-    </ScrollablePane>
+
+      <div style={{ height: '100%', position: 'relative' }}>
+        <ScrollablePane>
+          <CardTableV2
+            cardNoMarginTop
+            loading={listLoading}
+            items={historyTable || []}
+            columns={historyTableColumns}
+            onRowClicked={handleRowClick}
+          />
+        </ScrollablePane>
+      </div>
+    </div>
   )
 }

--- a/ui/lib/apps/SearchLogs/components/SearchHistory.tsx
+++ b/ui/lib/apps/SearchLogs/components/SearchHistory.tsx
@@ -13,6 +13,7 @@ import {
   Selection,
   SelectionMode,
 } from 'office-ui-fabric-react/lib/DetailsList'
+import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
 
 function componentRender({ target_stats: stats }) {
   const r: Array<string> = []
@@ -172,7 +173,7 @@ export default function SearchHistory() {
   ]
 
   return (
-    <div>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <Head
         title={t('search_logs.nav.history')}
         back={
@@ -196,14 +197,16 @@ export default function SearchHistory() {
           </>
         }
       />
-      <div style={{ backgroundColor: '#FFFFFF' }}>
-        <CardTableV2
-          columns={columns}
-          items={taskGroups || []}
-          selection={rowSelection}
-          selectionMode={SelectionMode.multiple}
-          style={{ marginTop: 0 }}
-        />
+      <div style={{ height: '100%', position: 'relative' }}>
+        <ScrollablePane>
+          <CardTableV2
+            cardNoMarginTop
+            columns={columns}
+            items={taskGroups || []}
+            selection={rowSelection}
+            selectionMode={SelectionMode.multiple}
+          />
+        </ScrollablePane>
       </div>
     </div>
   )


### PR DESCRIPTION
What did:

- Fix layout for dianosis history / log search history / profiling history tables when in small screen.

Before:

![1](https://user-images.githubusercontent.com/1284531/82025872-80fc5b80-96c4-11ea-94c4-4a6ab5cba61c.gif)

![2](https://user-images.githubusercontent.com/1284531/82025879-848fe280-96c4-11ea-9c62-e50860e03198.gif)

![3](https://user-images.githubusercontent.com/1284531/82025883-85287900-96c4-11ea-8940-45bc2c2241fb.gif)

After:

![5](https://user-images.githubusercontent.com/1284531/82025898-8ce81d80-96c4-11ea-87ee-ac825bb791c4.gif)
