### PR TITLE
ignore empty log searching results

### DIFF
--- a/pkg/apiserver/logsearch/task.go
+++ b/pkg/apiserver/logsearch/task.go
@@ -131,12 +131,12 @@ func (t *Task) setError(err error) {
 	t.model.Error = &errStr
 }
 
-func (t *Task) accumulateLogSize(dir *string) {
-	if dir != nil {
-		stat, err := os.Stat(*dir)
+func (t *Task) accumulateLogSize(path *string) {
+	if path != nil {
+		stat, err := os.Stat(*path)
 		if err != nil {
 			log.Warn("Can NOT fetch log file size for LogSearchTask",
-				zap.String("dir", *dir),
+				zap.String("dir", *path),
 				zap.Any("task", t),
 				zap.String("err", err.Error()),
 			)

--- a/pkg/apiserver/logsearch/task.go
+++ b/pkg/apiserver/logsearch/task.go
@@ -131,6 +131,21 @@ func (t *Task) setError(err error) {
 	t.model.Error = &errStr
 }
 
+func (t *Task) accumulateLogSize(dir *string) {
+	if dir != nil {
+		stat, err := os.Stat(*dir)
+		if err != nil {
+			log.Warn("Can NOT fetch log file size for LogSearchTask",
+				zap.String("dir", *dir),
+				zap.Any("task", t),
+				zap.String("err", err.Error()),
+			)
+		} else {
+			t.model.Size += stat.Size()
+		}
+	}
+}
+
 func (t *Task) SyncRun() {
 	defer func() {
 		if t.model.Error != nil {
@@ -144,15 +159,8 @@ func (t *Task) SyncRun() {
 			return
 		}
 		t.model.State = TaskStateFinished
-		stat, err := os.Stat(*t.model.LogStorePath)
-		if err != nil {
-			log.Warn("Can NOT fetch log file size for LogSearchTask",
-				zap.Any("task", t),
-				zap.String("err", err.Error()),
-			)
-		} else {
-			t.model.Size = stat.Size()
-		}
+		t.accumulateLogSize(t.model.LogStorePath)
+		t.accumulateLogSize(t.model.SlowLogStorePath)
 		log.Debug("LogSearchTask finished", zap.Any("task", t))
 		t.taskGroup.service.db.Save(t.model)
 	}()
@@ -233,19 +241,20 @@ func (t *Task) searchLog(client diagnosticspb.DiagnosticsClient, targetType diag
 	bufWriter := bufio.NewWriterSize(writer, 16*1024*1024) // 16M buffer size
 	defer bufWriter.Flush()
 
-	if targetType == diagnosticspb.SearchLogRequest_Normal {
-		t.model.LogStorePath = &savedPath
-	} else {
-		t.model.SlowLogStorePath = &savedPath
-	}
 	t.model.State = TaskStateRunning
-
 	previewLogLinesCount := 0
 	for {
 		res, err := stream.Recv()
 		if err != nil {
 			if err != io.EOF {
 				t.setError(err)
+			}
+			if previewLogLinesCount != 0 {
+				if targetType == diagnosticspb.SearchLogRequest_Normal {
+					t.model.LogStorePath = &savedPath
+				} else {
+					t.model.SlowLogStorePath = &savedPath
+				}
 			}
 			return
 		}

--- a/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
+++ b/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
@@ -22,7 +22,7 @@ const taskStateIcons = {
 function leafNodeProps(task: LogsearchTaskModel) {
   return {
     icon: taskStateIcons[task.state || TaskState.Error],
-    disableCheckbox: task.size ? task.state !== TaskState.Finished : true,
+    disableCheckbox: !task.size || task.state !== TaskState.Finished,
   }
 }
 

--- a/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
+++ b/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
@@ -22,7 +22,7 @@ const taskStateIcons = {
 function leafNodeProps(task: LogsearchTaskModel) {
   return {
     icon: taskStateIcons[task.state || TaskState.Error],
-    disableCheckbox: task.size ? task.state != TaskState.Finished : true,
+    disableCheckbox: task.size ? task.state !== TaskState.Finished : true,
   }
 }
 


### PR DESCRIPTION
UCP https://github.com/pingcap-incubator/tidb-dashboard/issues/507
Fix #492

Also, disable the tree node in log searching progress sidebar if the related task fails or has no searching results

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>