### PR TITLE
[DNM] Workaround for TiDB #17287

### DIFF
--- a/pkg/apiserver/utils/sql.go
+++ b/pkg/apiserver/utils/sql.go
@@ -46,7 +46,7 @@ func EscapeSQL(sql string) string {
 func EscapedStringList(params []string) string {
 	p := make([]string, 0)
 	for _, v := range params {
-		p = append(p, `"%s"`, EscapeSQL(v))
+		p = append(p, fmt.Sprintf(`"%s"`, EscapeSQL(v)))
 	}
 	return strings.Join(p, ", ")
 }

--- a/pkg/apiserver/utils/sql.go
+++ b/pkg/apiserver/utils/sql.go
@@ -1,6 +1,9 @@
 package utils
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func EscapeSQL(sql string) string {
 	dest := make([]byte, 0, 2*len(sql))

--- a/pkg/apiserver/utils/sql.go
+++ b/pkg/apiserver/utils/sql.go
@@ -1,0 +1,52 @@
+package utils
+
+import "strings"
+
+func EscapeSQL(sql string) string {
+	dest := make([]byte, 0, 2*len(sql))
+	var escape byte
+	for i := 0; i < len(sql); i++ {
+		c := sql[i]
+
+		escape = 0
+
+		switch c {
+		case 0: /* Must be escaped for 'mysql' */
+			escape = '0'
+			break
+		case '\n': /* Must be escaped for logs */
+			escape = 'n'
+			break
+		case '\r':
+			escape = 'r'
+			break
+		case '\\':
+			escape = '\\'
+			break
+		case '\'':
+			escape = '\''
+			break
+		case '"': /* Better safe than sorry */
+			escape = '"'
+			break
+		case '\032': /* This gives problems on Win32 */
+			escape = 'Z'
+		}
+
+		if escape != 0 {
+			dest = append(dest, '\\', escape)
+		} else {
+			dest = append(dest, c)
+		}
+	}
+
+	return string(dest)
+}
+
+func EscapedStringList(params []string) string {
+	p := make([]string, 0)
+	for _, v := range params {
+		p = append(p, `"%s"`, EscapeSQL(v))
+	}
+	return strings.Join(p, ", ")
+}


### PR DESCRIPTION
This PR is a workaround for https://github.com/pingcap/tidb/issues/17287 that does not use prepared statements, but use a less secure manual escape. The escaping algorithm comes from https://gist.github.com/siddontang/8875771. Notice that it is mostly a general knowledge that using SQL escape in 2020 is considered bad, so this PR shall be reverted back to use prepared statements after https://github.com/pingcap/tidb/issues/17287 is fixed.