### PR TITLE
Diagnose report: fix disk total query

### DIFF
--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -2159,7 +2159,7 @@ func GetClusterHardwareInfoTable(startTime, endTime string, db *gorm.DB) (TableD
 		}
 		m[s].memory = memCnt
 	}
-	sql = "SELECT `INSTANCE`,`DEVICE_NAME`,`VALUE` from information_schema.CLUSTER_HARDWARE where `NAME` = 'total' AND `DEVICE_TYPE` = 'disk' AND `DEVICE_NAME` NOT LIKE '/dev/loop%' AND (`DEVICE_NAME` LIKE '/dev%' or `DEVICE_NAME` LIKE 'sda%' or`DEVICE_NAME` LIKE 'nvme%') group by instance,device_name,value"
+	sql = "SELECT `INSTANCE`,`DEVICE_NAME`,`VALUE` from information_schema.CLUSTER_HARDWARE where `NAME` = 'total' AND `DEVICE_TYPE` = 'disk'"
 	rows, err = querySQL(db, sql)
 	if err != nil {
 		return table, err


### PR DESCRIPTION
Signed-off-by: Kaige Ye <yekaige2010@gmail.com>

This PR is intended to close this issue: https://github.com/tidb-challenge-program/bug-hunting-issue/issues/101

Explanation:

What I changed in this PR is to delete this condition:

```sql
AND `DEVICE_NAME` NOT LIKE '/dev/loop%' AND (`DEVICE_NAME` LIKE '/dev%' or `DEVICE_NAME` LIKE 'sda%' or`DEVICE_NAME` LIKE 'nvme%') group by instance,device_name,value
```

after beautify:

```sql
AND `DEVICE_NAME` NOT LIKE '/dev/loop%' 
AND (`DEVICE_NAME` LIKE '/dev%' 
  or `DEVICE_NAME` LIKE 'sda%' 
  or `DEVICE_NAME` LIKE 'nvme%') 
group by instance,device_name,value
```

- first of all, the last `group by` is useless, since each row the result will just be saved into a map
- `DEVICE_NAME` LIKE '/dev%' is useless, because the system info retrived from RPC doesn't not include this prefix
-  `DEVICE_NAME` LIKE 'sda%'  or `DEVICE_NAME` LIKE 'nvme%' is not enough, because `sdb%`/`sdc%`/`vda%` are also valid, more than that, we should not have any assumption on the name
- For the `DEVICE_NAME` NOT LIKE '/dev/loop%' part, if it should be hidden in dashboard, the right place to do that is to filter it in the datasouce(i.e. these info should be filtered in TiDB/PD/TiKV/TiFlash server info collector)

Another thing is, from a designer's perspective, dashboard SHOULD NOT filter any thing the underline services' report. If anything should be filtered, they should be filtered in the underline services, or these infomation will become junk info, no one use it. The only situation I can imagine to do the filter in dashboard is to do some temporary hack.
