### PR TITLE
Some ui refinements

### DIFF
--- a/ui/lib/apps/SearchLogs/pages/LogSearchHistory.tsx
+++ b/ui/lib/apps/SearchLogs/pages/LogSearchHistory.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button } from 'antd'
+import { Badge, Button, Modal, Space } from 'antd'
 import moment, { Moment } from 'moment'
 import {
   Selection,
@@ -9,7 +9,7 @@ import { RangeValue } from 'rc-picker/lib/interface'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { ArrowLeftOutlined } from '@ant-design/icons'
+import { ArrowLeftOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
 
 import client, { LogsearchTaskGroupModel } from '@lib/client'
 import { CardTableV2, Head } from '@lib/components'
@@ -101,23 +101,43 @@ export default function LogSearchingHistory() {
   }
 
   async function handleDeleteSelected() {
-    for (const taskGroupID of selectedRowKeys) {
-      await client.getInstance().logsTaskgroupsIdDelete(taskGroupID)
-      const res = await client.getInstance().logsTaskgroupsGet()
-      setTaskGroups(res.data)
-    }
+    Modal.confirm({
+      title: t('search_logs.history.delete_confirm_title'),
+      icon: <ExclamationCircleOutlined />,
+      content: t('search_logs.history.delete_selected_confirm_content'),
+      okText: t('search_logs.history.delete'),
+      cancelText: t('search_logs.common.cancel'),
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        for (const taskGroupID of selectedRowKeys) {
+          await client.getInstance().logsTaskgroupsIdDelete(taskGroupID)
+          const res = await client.getInstance().logsTaskgroupsGet()
+          setTaskGroups(res.data)
+        }
+      },
+    })
   }
 
   async function handleDeleteAll() {
-    const allKeys = taskGroups.map((taskGroup) => taskGroup.id)
-    for (const key of allKeys) {
-      if (key === undefined) {
-        continue
-      }
-      await client.getInstance().logsTaskgroupsIdDelete(key + '')
-    }
-    const res = await client.getInstance().logsTaskgroupsGet()
-    setTaskGroups(res.data)
+    Modal.confirm({
+      title: t('search_logs.history.delete_confirm_title'),
+      icon: <ExclamationCircleOutlined />,
+      content: t('search_logs.history.delete_all_confirm_content'),
+      okText: t('search_logs.history.delete'),
+      cancelText: t('search_logs.common.cancel'),
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        const allKeys = taskGroups.map((taskGroup) => taskGroup.id)
+        for (const key of allKeys) {
+          if (key === undefined) {
+            continue
+          }
+          await client.getInstance().logsTaskgroupsIdDelete(key + '')
+        }
+        const res = await client.getInstance().logsTaskgroupsGet()
+        setTaskGroups(res.data)
+      },
+    })
   }
 
   const rowSelection = new Selection({
@@ -182,19 +202,22 @@ export default function LogSearchingHistory() {
           </Link>
         }
         titleExtra={
-          <>
+          <Space>
             <Button
               danger
               onClick={handleDeleteSelected}
-              disabled={selectedRowKeys.length < 1}
-              style={{ marginRight: 16 }}
+              disabled={selectedRowKeys.length === 0}
             >
               {t('search_logs.history.delete_selected')}
             </Button>
-            <Button danger onClick={handleDeleteAll}>
+            <Button
+              danger
+              onClick={handleDeleteAll}
+              disabled={taskGroups?.length === 0}
+            >
               {t('search_logs.history.delete_all')}
             </Button>
-          </>
+          </Space>
         }
       />
       <div style={{ height: '100%', position: 'relative' }}>

--- a/ui/lib/apps/SearchLogs/translations/en.yaml
+++ b/ui/lib/apps/SearchLogs/translations/en.yaml
@@ -44,3 +44,6 @@ search_logs:
     action: Action
     detail: Detail
     delete: Delete
+    delete_confirm_title: Delete Log Search Histories
+    delete_selected_confirm_content: Are you sure you want to delete selected log search histories?
+    delete_all_confirm_content: Are you sure you want to delete all log search histories?

--- a/ui/lib/apps/SearchLogs/translations/zh-CN.yaml
+++ b/ui/lib/apps/SearchLogs/translations/zh-CN.yaml
@@ -44,3 +44,6 @@ search_logs:
     action: 操作
     detail: 查看详情
     delete: 删除
+    delete_confirm_title: 删除搜索历史
+    delete_selected_confirm_content: 确认要删除选中的搜索历史吗？
+    delete_all_confirm_content: 确认要删除所有的搜索历史吗？

--- a/ui/lib/apps/SlowQuery/pages/Detail/DetailTabCopr.tsx
+++ b/ui/lib/apps/SlowQuery/pages/Detail/DetailTabCopr.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
+
 import { SlowquerySlowQuery } from '@lib/client'
-import { CardTableV2 } from '@lib/components'
-import { getValueFormat } from '@baurine/grafana-value-formats'
+import { CardTableV2, ShortValueWithTooltip } from '@lib/components'
 import { valueColumns } from '@lib/utils/tableColumns'
 
 export interface ITabCoprProps {
@@ -12,15 +12,15 @@ export default function TabCopr({ data }: ITabCoprProps) {
   const items = [
     {
       key: 'request_count',
-      value: data.request_count,
+      value: <ShortValueWithTooltip value={data.request_count} />,
     },
     {
       key: 'process_keys',
-      value: getValueFormat('short')(data.process_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.process_keys} />,
     },
     {
       key: 'total_keys',
-      value: getValueFormat('short')(data.total_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.total_keys} />,
     },
     {
       key: 'cop_proc_addr',

--- a/ui/lib/apps/SlowQuery/pages/Detail/DetailTabTxn.tsx
+++ b/ui/lib/apps/SlowQuery/pages/Detail/DetailTabTxn.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { SlowquerySlowQuery } from '@lib/client'
-import { CardTableV2 } from '@lib/components'
 import { getValueFormat } from '@baurine/grafana-value-formats'
+
+import { SlowquerySlowQuery } from '@lib/client'
+import { CardTableV2, ShortValueWithTooltip } from '@lib/components'
 import { valueColumns } from '@lib/utils/tableColumns'
 
 export interface ITabTxnProps {
@@ -16,7 +17,7 @@ export default function TabCopr({ data }: ITabTxnProps) {
     },
     {
       key: 'write_keys',
-      value: getValueFormat('short')(data.write_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.write_keys} />,
     },
     {
       key: 'write_size',
@@ -24,11 +25,11 @@ export default function TabCopr({ data }: ITabTxnProps) {
     },
     {
       key: 'prewrite_regions',
-      value: getValueFormat('short')(data.prewrite_region || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.prewrite_region} />,
     },
     {
       key: 'txn_retry',
-      value: data.txn_retry,
+      value: <ShortValueWithTooltip value={data.txn_retry} />,
     },
   ]
   const columns = valueColumns('slow_query.fields.')

--- a/ui/lib/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
+++ b/ui/lib/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
@@ -1,8 +1,15 @@
-import React from 'react'
-import { StatementModel } from '@lib/client'
-import { CardTableV2, DateTime, Pre, TextWrap } from '@lib/components'
-import { getValueFormat } from '@baurine/grafana-value-formats'
 import { Tooltip } from 'antd'
+import React from 'react'
+import { getValueFormat } from '@baurine/grafana-value-formats'
+
+import { StatementModel } from '@lib/client'
+import {
+  CardTableV2,
+  DateTime,
+  Pre,
+  ShortValueWithTooltip,
+  TextWrap,
+} from '@lib/components'
 import { valueColumns } from '@lib/utils/tableColumns'
 
 export interface ITabBasicProps {
@@ -34,14 +41,23 @@ export default function TabBasic({ data }: ITabBasicProps) {
         <DateTime.Calendar unixTimestampMs={data.last_seen * 1000} />
       ),
     },
-    { key: 'exec_count', value: data.exec_count },
+    {
+      key: 'exec_count',
+      value: <ShortValueWithTooltip value={data.exec_count} />,
+    },
     {
       key: 'sum_latency',
       value: getValueFormat('ns')(data.sum_latency || 0, 1),
     },
     { key: 'sample_user', value: data.sample_user },
-    { key: 'sum_errors', value: data.sum_errors },
-    { key: 'sum_warnings', value: data.sum_warnings },
+    {
+      key: 'sum_errors',
+      value: <ShortValueWithTooltip value={data.sum_errors} />,
+    },
+    {
+      key: 'sum_warnings',
+      value: <ShortValueWithTooltip value={data.sum_warnings} />,
+    },
     {
       key: 'avg_mem',
       value: getValueFormat('bytes')(data.avg_mem || 0, 1),

--- a/ui/lib/apps/Statement/pages/Detail/PlanDetailTabCopr.tsx
+++ b/ui/lib/apps/Statement/pages/Detail/PlanDetailTabCopr.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
+
 import { StatementModel } from '@lib/client'
-import { CardTableV2 } from '@lib/components'
-import { getValueFormat } from '@baurine/grafana-value-formats'
+import { CardTableV2, ShortValueWithTooltip } from '@lib/components'
 import { valueColumns } from '@lib/utils/tableColumns'
 
 export interface ITabCoprProps {
@@ -13,19 +13,19 @@ export default function TabCopr({ data }: ITabCoprProps) {
     { key: 'sum_cop_task_num', value: data.sum_cop_task_num },
     {
       key: 'avg_processed_keys',
-      value: getValueFormat('short')(data.avg_processed_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.avg_processed_keys} />,
     },
     {
       key: 'max_processed_keys',
-      value: getValueFormat('short')(data.max_processed_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.max_processed_keys} />,
     },
     {
       key: 'avg_total_keys',
-      value: getValueFormat('short')(data.avg_total_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.avg_total_keys} />,
     },
     {
       key: 'max_total_keys',
-      value: getValueFormat('short')(data.max_total_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.max_total_keys} />,
     },
   ]
   const columns = valueColumns('statement.fields.')

--- a/ui/lib/apps/Statement/pages/Detail/PlanDetailTabTxn.tsx
+++ b/ui/lib/apps/Statement/pages/Detail/PlanDetailTabTxn.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { StatementModel } from '@lib/client'
-import { CardTableV2 } from '@lib/components'
 import { getValueFormat } from '@baurine/grafana-value-formats'
+
+import { StatementModel } from '@lib/client'
+import { CardTableV2, ShortValueWithTooltip } from '@lib/components'
 import { valueColumns } from '@lib/utils/tableColumns'
 
 export interface ITabTxnProps {
@@ -12,19 +13,19 @@ export default function TabCopr({ data }: ITabTxnProps) {
   const items = [
     {
       key: 'avg_affected_rows',
-      value: data.avg_affected_rows,
+      value: <ShortValueWithTooltip value={data.avg_affected_rows} />,
     },
     {
       key: 'sum_backoff_times',
-      value: data.sum_backoff_times,
+      value: <ShortValueWithTooltip value={data.sum_backoff_times} />,
     },
     {
       key: 'avg_write_keys',
-      value: getValueFormat('short')(data.avg_write_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.avg_write_keys} />,
     },
     {
       key: 'max_write_keys',
-      value: getValueFormat('short')(data.max_write_keys || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.max_write_keys} />,
     },
     {
       key: 'avg_write_size',
@@ -36,19 +37,19 @@ export default function TabCopr({ data }: ITabTxnProps) {
     },
     {
       key: 'avg_prewrite_regions',
-      value: getValueFormat('short')(data.avg_prewrite_regions || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.avg_prewrite_regions} />,
     },
     {
       key: 'max_prewrite_regions',
-      value: getValueFormat('short')(data.max_prewrite_regions || 0, 0, 1),
+      value: <ShortValueWithTooltip value={data.max_prewrite_regions} />,
     },
     {
       key: 'avg_txn_retry',
-      value: data.avg_txn_retry,
+      value: <ShortValueWithTooltip value={data.avg_txn_retry} />,
     },
     {
       key: 'max_txn_retry',
-      value: data.max_txn_retry,
+      value: <ShortValueWithTooltip value={data.max_txn_retry} />,
     },
   ]
   const columns = valueColumns('statement.fields.')

--- a/ui/lib/components/ShortValueWithTooltip/index.tsx
+++ b/ui/lib/components/ShortValueWithTooltip/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Tooltip } from 'antd'
+import { getValueFormat } from '@baurine/grafana-value-formats'
+
+export interface IShortValueWithTooltipProps {
+  value?: number
+  scaledDecimal?: number
+}
+
+export default function ShortValueWithTooltip({
+  value = 0,
+  scaledDecimal = 1,
+}: IShortValueWithTooltipProps) {
+  return (
+    <Tooltip title={value}>
+      <span>{getValueFormat('short')(value || 0, 0, scaledDecimal)}</span>
+    </Tooltip>
+  )
+}

--- a/ui/lib/components/index.ts
+++ b/ui/lib/components/index.ts
@@ -38,6 +38,8 @@ export * from './TimeRangeSelector'
 export { default as TimeRangeSelector } from './TimeRangeSelector'
 export * from './AnimatedSkeleton'
 export { default as AnimatedSkeleton } from './AnimatedSkeleton'
+export * from './ShortValueWithTooltip'
+export { default as ShortValueWithTooltip } from './ShortValueWithTooltip'
 
 export { default as LanguageDropdown } from './LanguageDropdown'
 export { default as ParamsPageWrapper } from './ParamsPageWrapper'


### PR DESCRIPTION
close #513, #501 

What did:

- Show confirm before deleting log search histories
- Show tooltip for short values in the statement / slow query detail page tables

Screenshots:

![企业微信20200601024106](https://user-images.githubusercontent.com/1284531/83382676-385bd680-a416-11ea-8eed-78d36c6a3b19.png)

![企业微信20200601024248](https://user-images.githubusercontent.com/1284531/83382681-3a259a00-a416-11ea-8dcb-7125c50a1f07.png)
