### PR TITLE
ui: refine handle errors

### DIFF
--- a/ui/dashboardApp/client.js
+++ b/ui/dashboardApp/client.js
@@ -28,8 +28,10 @@ function initAxios() {
       singleSpa.navigateToUrl('#' + auth.signInRoute)
       err.handled = true
     } else if (err.message === 'Network Error') {
-      message.error(i18next.t('error.message.network'))
+      const content = i18next.t('error.message.network')
+      message.error({ content, key: 'network_error' }) // use key to avoid multiple message boxes
       err.handled = true
+      err.msg = content // use `err.message` doesn't work
     }
     return Promise.reject(err)
   })

--- a/ui/lib/apps/Overview/components/Instances.tsx
+++ b/ui/lib/apps/Overview/components/Instances.tsx
@@ -12,12 +12,14 @@ import {
 import client from '@lib/client'
 import { AnimatedSkeleton, Card } from '@lib/components'
 import { useClientRequest } from '@lib/utils/useClientRequest'
+import getApiErrorsMsg from '@lib/utils/apiErrorsMsg'
 
 export default function Instances() {
   const { t } = useTranslation()
   const { data, isLoading, error } = useClientRequest((cancelToken) =>
     client.getInstance().topologyAllGet({ cancelToken })
   )
+  const errorMsg = useMemo(() => getApiErrorsMsg([error]), [error])
 
   const statusMap = useMemo(() => {
     if (!data) {
@@ -66,7 +68,7 @@ export default function Instances() {
       noMarginLeft
     >
       <AnimatedSkeleton showSkeleton={isLoading}>
-        {error && <Alert message="Error" type="error" showIcon />}
+        {error && <Alert message={errorMsg} type="error" showIcon />}
         {data &&
           statusMap.map((s) => {
             return (

--- a/ui/lib/components/CardTableV2/index.tsx
+++ b/ui/lib/components/CardTableV2/index.tsx
@@ -204,23 +204,20 @@ function CardTableV2(props: ICardTableV2Props) {
       <AnimatedSkeleton
         showSkeleton={items.length === 0 && loading && !errorMsg}
       >
-        {errorMsg ? (
-          <Alert message={errorMsg} type="error" showIcon />
-        ) : (
-          <div className={styles.cardTableContent}>
-            <MemoDetailsList
-              selectionMode={SelectionMode.none}
-              constrainMode={ConstrainMode.unconstrained}
-              layoutMode={DetailsListLayoutMode.justified}
-              onRenderDetailsHeader={renderStickyHeader}
-              onRenderRow={onRowClicked ? renderClickableRow : undefined}
-              onRenderCheckbox={onRenderCheckbox}
-              columns={finalColumns}
-              items={finalItems}
-              {...restProps}
-            />
-          </div>
-        )}
+        {errorMsg && <Alert message={errorMsg} type="error" showIcon />}
+        <div className={styles.cardTableContent}>
+          <MemoDetailsList
+            selectionMode={SelectionMode.none}
+            constrainMode={ConstrainMode.unconstrained}
+            layoutMode={DetailsListLayoutMode.justified}
+            onRenderDetailsHeader={renderStickyHeader}
+            onRenderRow={onRowClicked ? renderClickableRow : undefined}
+            onRenderCheckbox={onRenderCheckbox}
+            columns={finalColumns}
+            items={finalItems}
+            {...restProps}
+          />
+        </div>
       </AnimatedSkeleton>
     </Card>
   )

--- a/ui/lib/components/MetricChart/index.tsx
+++ b/ui/lib/components/MetricChart/index.tsx
@@ -227,7 +227,7 @@ export default function MetricChart({
   ) {
     inner = (
       <div style={{ height: HEIGHT }}>
-        <Alert message={errorMsg || 'Error'} type="error" showIcon />
+        <Alert message={errorMsg} type="error" showIcon />
       </div>
     )
   } else {

--- a/ui/lib/utils/apiErrorsMsg.ts
+++ b/ui/lib/utils/apiErrorsMsg.ts
@@ -2,6 +2,6 @@ import _ from 'lodash'
 
 export default function getApiErrorsMsg(errors: any[]) {
   return _.uniq(
-    _.map(errors, (err) => err?.response?.data?.message || '')
-  ).join('; ')
+    _.map(errors, (err) => err?.response?.data?.message || err?.msg || '')
+  )[0]
 }


### PR DESCRIPTION
What did:

- Use key for the message box to avoid multiple same message boxes
- Only show the first error if has multiple errors
- Show "Network Error" in the Alert component as well
  
  ![企业微信20200604045627](https://user-images.githubusercontent.com/1284531/83739468-3436ef80-a688-11ea-8af8-28656fd57a93.png)

  ![企业微信20200604045943](https://user-images.githubusercontent.com/1284531/83739488-3a2cd080-a688-11ea-9d3a-4a59b3685eaf.png)


TODO:

- Move Alert out of CardTableV2 after `label` branch in PR #591 is merged. Currently moving out loses the margin.

  ![企业微信20200604045236](https://user-images.githubusercontent.com/1284531/83739391-19647b00-a688-11ea-9941-90b86f80e0da.png)

  ![企业微信20200604045251](https://user-images.githubusercontent.com/1284531/83739415-22ede300-a688-11ea-95a0-534aaf4f2844.png)

