### PR TITLE
ui: remove deprecated <big> element

### DIFF
--- a/ui/lib/apps/Overview/components/Instances.tsx
+++ b/ui/lib/apps/Overview/components/Instances.tsx
@@ -13,6 +13,8 @@ import {
 import { RightOutlined, WarningOutlined } from '@ant-design/icons'
 import { Stack } from 'office-ui-fabric-react/lib/Stack'
 
+import styles from './Styles.module.less'
+
 function ComponentItem(props: {
   name: string
   resp: { data?: { status?: number }[]; isLoading: boolean; error?: any }
@@ -43,7 +45,7 @@ function ComponentItem(props: {
         <Descriptions column={1}>
           <Descriptions.Item label={name}>
             <Typography.Text type={upNums === allNums ? undefined : 'danger'}>
-              <big>{upNums}</big>
+              <span className={styles.big}>{upNums}</span>
               <small> / {allNums}</small>
             </Typography.Text>
           </Descriptions.Item>

--- a/ui/lib/apps/Overview/components/Styles.module.less
+++ b/ui/lib/apps/Overview/components/Styles.module.less
@@ -1,0 +1,3 @@
+.big {
+  font-size: larger;
+}


### PR DESCRIPTION
This feature is obsolete. Although it may still work in some browsers, its use is discouraged since it could be removed at any time. Try to avoid using it.