### PR TITLE
*: tidb forwarder support http request and refactor keyviz

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/pingcap/log"
 	flag "github.com/spf13/pflag"
-	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -176,12 +175,11 @@ func main() {
 		cliConfig.CoreConfig,
 		apiserver.StoppedHandler,
 		assets,
-		func(cfg *config.Config, httpClient *http.Client, etcdClient *clientv3.Client) *keyvisualregion.PDDataProvider {
-			return &keyvisualregion.PDDataProvider{
+		func(cfg *config.Config, httpClient *http.Client) *keyvisualregion.DataProvider {
+			return &keyvisualregion.DataProvider{
 				FileStartTime:  cliConfig.KVFileStartTime,
 				FileEndTime:    cliConfig.KVFileEndTime,
 				PeriodicGetter: keyvisualinput.NewAPIPeriodicGetter(cliConfig.CoreConfig.PDEndPoint, httpClient),
-				EtcdClient:     etcdClient,
 			}
 		},
 	)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	cors "github.com/rs/cors/wrapper/gin"
-	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/fx"
 
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/clusterinfo"
@@ -55,7 +54,7 @@ var (
 	once sync.Once
 )
 
-type PDDataProviderConstructor func(*config.Config, *http.Client, *clientv3.Client) *keyvisualregion.PDDataProvider
+type DataProviderConstructor func(*config.Config, *http.Client) *keyvisualregion.DataProvider
 
 type Service struct {
 	app    *fx.App
@@ -64,15 +63,15 @@ type Service struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	config            *config.Config
-	newPDDataProvider PDDataProviderConstructor
-	stoppedHandler    http.Handler
-	uiAssetFS         http.FileSystem
+	config          *config.Config
+	newDataProvider DataProviderConstructor
+	stoppedHandler  http.Handler
+	uiAssetFS       http.FileSystem
 
 	apiHandlerEngine *gin.Engine
 }
 
-func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.FileSystem, newPDDataProvider PDDataProviderConstructor) *Service {
+func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.FileSystem, newDataProvider DataProviderConstructor) *Service {
 	once.Do(func() {
 		// These global modification will be effective only for the first invoke.
 		_ = godotenv.Load()
@@ -80,11 +79,11 @@ func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.
 	})
 
 	return &Service{
-		status:            utils.NewServiceStatus(),
-		config:            cfg,
-		newPDDataProvider: newPDDataProvider,
-		stoppedHandler:    stoppedHandler,
-		uiAssetFS:         uiAssetFS,
+		status:          utils.NewServiceStatus(),
+		config:          cfg,
+		newDataProvider: newDataProvider,
+		stoppedHandler:  stoppedHandler,
+		uiAssetFS:       uiAssetFS,
 	}
 }
 
@@ -104,7 +103,7 @@ func (s *Service) Start(ctx context.Context) error {
 		fx.Provide(
 			newAPIHandlerEngine,
 			s.provideLocals,
-			s.newPDDataProvider,
+			s.newDataProvider,
 			dbstore.NewDBStore,
 			pd.NewEtcdClient,
 			pd.NewPDClient,

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -54,7 +54,7 @@ var (
 	once sync.Once
 )
 
-type DataProviderConstructor func(*config.Config, *http.Client) *keyvisualregion.DataProvider
+type KeyVisualProviderConstructor func(*config.Config, *http.Client) *keyvisualregion.DataProvider
 
 type Service struct {
 	app    *fx.App
@@ -63,15 +63,15 @@ type Service struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	config          *config.Config
-	newDataProvider DataProviderConstructor
-	stoppedHandler  http.Handler
-	uiAssetFS       http.FileSystem
+	config               *config.Config
+	newKeyVisualProvider KeyVisualProviderConstructor
+	stoppedHandler       http.Handler
+	uiAssetFS            http.FileSystem
 
 	apiHandlerEngine *gin.Engine
 }
 
-func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.FileSystem, newDataProvider DataProviderConstructor) *Service {
+func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.FileSystem, newKeyVisualProvider KeyVisualProviderConstructor) *Service {
 	once.Do(func() {
 		// These global modification will be effective only for the first invoke.
 		_ = godotenv.Load()
@@ -79,11 +79,11 @@ func NewService(cfg *config.Config, stoppedHandler http.Handler, uiAssetFS http.
 	})
 
 	return &Service{
-		status:          utils.NewServiceStatus(),
-		config:          cfg,
-		newDataProvider: newDataProvider,
-		stoppedHandler:  stoppedHandler,
-		uiAssetFS:       uiAssetFS,
+		status:               utils.NewServiceStatus(),
+		config:               cfg,
+		newKeyVisualProvider: newKeyVisualProvider,
+		stoppedHandler:       stoppedHandler,
+		uiAssetFS:            uiAssetFS,
 	}
 }
 
@@ -103,7 +103,7 @@ func (s *Service) Start(ctx context.Context) error {
 		fx.Provide(
 			newAPIHandlerEngine,
 			s.provideLocals,
-			s.newDataProvider,
+			s.newKeyVisualProvider,
 			dbstore.NewDBStore,
 			pd.NewEtcdClient,
 			pd.NewPDClient,

--- a/pkg/apiserver/logsearch/scheduler.go
+++ b/pkg/apiserver/logsearch/scheduler.go
@@ -58,7 +58,7 @@ func (s *Scheduler) AsyncStart(taskGroupModel *TaskGroupModel, tasksModel []*Tas
 		return false
 	}
 
-	taskGroup.InitTasks(s.service.ctx, tasksModel)
+	taskGroup.InitTasks(s.service.lifecycleCtx, tasksModel)
 
 	go func() {
 		taskGroup.SyncRun()

--- a/pkg/apiserver/logsearch/service.go
+++ b/pkg/apiserver/logsearch/service.go
@@ -34,7 +34,7 @@ import (
 )
 
 type Service struct {
-	ctx context.Context
+	lifecycleCtx context.Context
 
 	config            *config.Config
 	logStoreDirectory string
@@ -64,7 +64,7 @@ func NewService(lc fx.Lifecycle, config *config.Config, db *dbstore.DB) *Service
 
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			service.ctx = ctx
+			service.lifecycleCtx = ctx
 			return nil
 		},
 	})

--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/fx"
 
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
@@ -38,7 +39,7 @@ type tableDetail struct {
 
 type tidbLabelStrategy struct {
 	Config     *config.Config
-	Provider   *region.PDDataProvider
+	EtcdClient *clientv3.Client
 	HTTPClient *http.Client
 
 	TableMap      sync.Map
@@ -48,10 +49,10 @@ type tidbLabelStrategy struct {
 }
 
 // TiDBLabelStrategy implements the LabelStrategy interface. Get Label Information from TiDB.
-func TiDBLabelStrategy(lc fx.Lifecycle, wg *sync.WaitGroup, cfg *config.Config, provider *region.PDDataProvider, httpClient *http.Client, forwarder *tidb.Forwarder) LabelStrategy {
+func TiDBLabelStrategy(lc fx.Lifecycle, wg *sync.WaitGroup, cfg *config.Config, etcdClient *clientv3.Client, httpClient *http.Client, forwarder *tidb.Forwarder) LabelStrategy {
 	s := &tidbLabelStrategy{
 		Config:        cfg,
-		Provider:      provider,
+		EtcdClient:    etcdClient,
 		HTTPClient:    httpClient,
 		forwarder:     forwarder,
 		SchemaVersion: -1,

--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
@@ -40,7 +39,6 @@ type tableDetail struct {
 type tidbLabelStrategy struct {
 	Config     *config.Config
 	EtcdClient *clientv3.Client
-	HTTPClient *http.Client
 
 	TableMap      sync.Map
 	forwarder     *tidb.Forwarder
@@ -49,11 +47,10 @@ type tidbLabelStrategy struct {
 }
 
 // TiDBLabelStrategy implements the LabelStrategy interface. Get Label Information from TiDB.
-func TiDBLabelStrategy(lc fx.Lifecycle, wg *sync.WaitGroup, cfg *config.Config, etcdClient *clientv3.Client, httpClient *http.Client, forwarder *tidb.Forwarder) LabelStrategy {
+func TiDBLabelStrategy(lc fx.Lifecycle, wg *sync.WaitGroup, cfg *config.Config, etcdClient *clientv3.Client, forwarder *tidb.Forwarder) LabelStrategy {
 	s := &tidbLabelStrategy{
 		Config:        cfg,
 		EtcdClient:    etcdClient,
-		HTTPClient:    httpClient,
 		forwarder:     forwarder,
 		SchemaVersion: -1,
 	}

--- a/pkg/keyvisual/decorator/tidb_requests.go
+++ b/pkg/keyvisual/decorator/tidb_requests.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -34,9 +33,9 @@ const (
 )
 
 var (
-	ErrNS                    = errorx.NewNamespace("error.keyvisual")
-	ErrNSDecorator           = ErrNS.NewSubNamespace("decorator")
-	ErrTiDBHTTPRequestFailed = ErrNSDecorator.NewType("tidb_http_request_failed")
+	ErrNS          = errorx.NewNamespace("error.keyvisual")
+	ErrNSDecorator = ErrNS.NewSubNamespace("decorator")
+	ErrInvalidData = ErrNSDecorator.NewType("invalid_data")
 )
 
 func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
@@ -62,26 +61,20 @@ func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
 
 	// get all database info
 	var dbInfos []*model.DBInfo
-	reqScheme := "http"
-	if s.Config.ClusterTLSConfig != nil {
-		reqScheme = "https"
-	}
-	hostname, port := s.forwarder.GetStatusConnProps()
-	tidbEndpoint := fmt.Sprintf("%s://%s:%d", reqScheme, hostname, port)
-	if err := request(tidbEndpoint, "schema", &dbInfos, s.HTTPClient); err != nil {
-		log.Error("fail to send schema request to TiDB", zap.String("endpoint", tidbEndpoint), zap.Error(err))
+	if err := s.request("/schema", &dbInfos); err != nil {
+		log.Error("fail to send schema request to TiDB", zap.Error(err))
 		return
 	}
 
 	// get all table info
-	var tableInfos []*model.TableInfo
 	updateSuccess := true
 	for _, db := range dbInfos {
 		if db.State == model.StateNone {
 			continue
 		}
-		if err := request(tidbEndpoint, fmt.Sprintf("schema/%s", db.Name.O), &tableInfos, s.HTTPClient); err != nil {
-			log.Error("fail to send schema request to TiDB", zap.String("endpoint", tidbEndpoint), zap.Error(err))
+		var tableInfos []*model.TableInfo
+		if err := s.request(fmt.Sprintf("/schema/%s", db.Name.O), &tableInfos); err != nil {
+			log.Error("fail to send schema request to TiDB", zap.Error(err))
 			updateSuccess = false
 			continue
 		}
@@ -117,20 +110,13 @@ func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
 	}
 }
 
-func request(endpoint string, path string, v interface{}, httpClient *http.Client) error {
-	uri := fmt.Sprintf("%s/%s", endpoint, path)
-
-	// FIXME: Better to assign a context
-	resp, err := httpClient.Get(uri) //nolint:gosec
+func (s *tidbLabelStrategy) request(path string, v interface{}) error {
+	data, err := s.forwarder.SendGetRequest(path)
 	if err != nil {
-		return ErrTiDBHTTPRequestFailed.Wrap(err, "TiDB HTTP API request failed")
+		return err
 	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return ErrTiDBHTTPRequestFailed.New("TiDB HTTP API returns non success status code")
+	if err = json.Unmarshal(data, v); err != nil {
+		return ErrInvalidData.Wrap(err, "TiDB schema API unmarshal failed")
 	}
-
-	decoder := json.NewDecoder(resp.Body)
-	return decoder.Decode(v)
+	return nil
 }

--- a/pkg/keyvisual/decorator/tidb_requests.go
+++ b/pkg/keyvisual/decorator/tidb_requests.go
@@ -42,7 +42,7 @@ var (
 func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
 	// check schema version
 	ectx, cancel := context.WithTimeout(ctx, etcdGetTimeout)
-	resp, err := s.Provider.EtcdClient.Get(ectx, schemaVersionPath)
+	resp, err := s.EtcdClient.Get(ectx, schemaVersionPath)
 	cancel()
 	if err != nil || len(resp.Kvs) != 1 {
 		log.Warn("failed to get tidb schema version", zap.Error(err))

--- a/pkg/keyvisual/input/api.go
+++ b/pkg/keyvisual/input/api.go
@@ -120,7 +120,7 @@ func read(data []byte) (*RegionsInfo, error) {
 
 func NewAPIPeriodicGetter(pdClient *pd.Client) regionpkg.RegionsInfoGenerator {
 	return func() (regionpkg.RegionsInfo, error) {
-		data, err := pdClient.SendGetRequest("/pd/api/v1/regions")
+		data, err := pdClient.SendGetRequest("/regions")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/keyvisual/input/api.go
+++ b/pkg/keyvisual/input/api.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	ErrNS                  = errorx.NewNamespace("error.keyvisual")
-	ErrNSInput             = ErrNS.NewSubNamespace("input")
-	ErrPDHTTPRequestFailed = ErrNSInput.NewType("pd_http_request_failed")
+	ErrNS          = errorx.NewNamespace("error.keyvisual")
+	ErrNSInput     = ErrNS.NewSubNamespace("input")
+	ErrInvalidData = ErrNSInput.NewType("invalid_data")
 )
 
 // RegionInfo records detail region info for api usage.
@@ -95,18 +95,18 @@ func (rs *RegionsInfo) GetValues(tag regionpkg.StatTag) []uint64 {
 func read(data []byte) (*RegionsInfo, error) {
 	regions := &RegionsInfo{}
 	if err := json.Unmarshal(data, regions); err != nil {
-		return nil, err
+		return nil, ErrInvalidData.Wrap(err, "PD regions API unmarshal failed")
 	}
 
 	for _, region := range regions.Regions {
 		startBytes, err := hex.DecodeString(region.StartKey)
 		if err != nil {
-			return nil, err
+			return nil, ErrInvalidData.Wrap(err, "PD regions API unmarshal failed")
 		}
 		region.StartKey = regionpkg.String(startBytes)
 		endBytes, err := hex.DecodeString(region.EndKey)
 		if err != nil {
-			return nil, err
+			return nil, ErrInvalidData.Wrap(err, "PD regions API unmarshal failed")
 		}
 		region.EndKey = regionpkg.String(endBytes)
 	}

--- a/pkg/keyvisual/input/api.go
+++ b/pkg/keyvisual/input/api.go
@@ -16,15 +16,12 @@ package input
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
 	"sort"
 
 	"github.com/joomcode/errorx"
 
 	regionpkg "github.com/pingcap-incubator/tidb-dashboard/pkg/keyvisual/region"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/pd"
 )
 
 var (
@@ -95,53 +92,38 @@ func (rs *RegionsInfo) GetValues(tag regionpkg.StatTag) []uint64 {
 	return values
 }
 
-func read(stream io.ReadCloser) (*RegionsInfo, error) {
-	defer stream.Close()
+func read(data []byte) (*RegionsInfo, error) {
 	regions := &RegionsInfo{}
-	decoder := json.NewDecoder(stream)
-	err := decoder.Decode(regions)
-	if err == nil {
-		var startBytes, endBytes []byte
-		for _, region := range regions.Regions {
-			startBytes, err = hex.DecodeString(region.StartKey)
-			if err != nil {
-				break
-			}
-			endBytes, err = hex.DecodeString(region.EndKey)
-			if err != nil {
-				break
-			}
-			region.StartKey = regionpkg.String(startBytes)
-			region.EndKey = regionpkg.String(endBytes)
-		}
+	if err := json.Unmarshal(data, regions); err != nil {
+		return nil, err
 	}
-	if err == nil {
-		sort.Slice(regions.Regions, func(i, j int) bool {
-			return regions.Regions[i].StartKey < regions.Regions[j].StartKey
-		})
-	}
-	return regions, err
-}
 
-func NewAPIPeriodicGetter(pdAddr string, client *http.Client) regionpkg.RegionsInfoGenerator {
-	addr := fmt.Sprintf("%s/pd/api/v1/regions", pdAddr)
-	return func() (regionsInfo regionpkg.RegionsInfo, err error) {
-		resp, err := client.Get(addr) //nolint:bodyclose,gosec
-		if err == nil {
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				var msg []byte
-				msg, err = ioutil.ReadAll(resp.Body)
-				if err != nil {
-					err = ErrPDHTTPRequestFailed.Wrap(err, "http status code: %d", resp.StatusCode)
-				} else {
-					err = ErrPDHTTPRequestFailed.New("http status code: %d, msg: %s", resp.StatusCode, msg)
-				}
-			}
-		}
+	for _, region := range regions.Regions {
+		startBytes, err := hex.DecodeString(region.StartKey)
 		if err != nil {
 			return nil, err
 		}
-		return read(resp.Body)
+		region.StartKey = regionpkg.String(startBytes)
+		endBytes, err := hex.DecodeString(region.EndKey)
+		if err != nil {
+			return nil, err
+		}
+		region.EndKey = regionpkg.String(endBytes)
+	}
+
+	sort.Slice(regions.Regions, func(i, j int) bool {
+		return regions.Regions[i].StartKey < regions.Regions[j].StartKey
+	})
+
+	return regions, nil
+}
+
+func NewAPIPeriodicGetter(pdClient *pd.Client) regionpkg.RegionsInfoGenerator {
+	return func() (regionpkg.RegionsInfo, error) {
+		data, err := pdClient.SendGetRequest("/pd/api/v1/regions")
+		if err != nil {
+			return nil, err
+		}
+		return read(data)
 	}
 }

--- a/pkg/keyvisual/input/file.go
+++ b/pkg/keyvisual/input/file.go
@@ -15,6 +15,7 @@ package input
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -59,8 +60,13 @@ func (input *fileInput) Background(ctx context.Context, stat *storage.Stat) {
 func readFile(fileTime time.Time) (*RegionsInfo, error) {
 	fileName := fileTime.Format("./data/20060102-15-04.json")
 	file, err := os.Open(fileName)
-	if err == nil {
-		return read(file)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	defer file.Close()
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	return read(data)
 }

--- a/pkg/keyvisual/input/file.go
+++ b/pkg/keyvisual/input/file.go
@@ -61,12 +61,12 @@ func readFile(fileTime time.Time) (*RegionsInfo, error) {
 	fileName := fileTime.Format("./data/20060102-15-04.json")
 	file, err := os.Open(fileName)
 	if err != nil {
-		return nil, err
+		return nil, ErrInvalidData.Wrap(err, "PD regions API unmarshal failed, from file %s", fileName)
 	}
 	defer file.Close()
 	data, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, ErrInvalidData.Wrap(err, "PD regions API unmarshal failed, from file %s", fileName)
 	}
 	return read(data)
 }

--- a/pkg/keyvisual/input/input.go
+++ b/pkg/keyvisual/input/input.go
@@ -28,7 +28,7 @@ type StatInput interface {
 	Background(ctx context.Context, stat *storage.Stat)
 }
 
-func NewStatInput(provider *region.PDDataProvider) StatInput {
+func NewStatInput(provider *region.DataProvider) StatInput {
 	if provider.FileStartTime == 0 && provider.FileEndTime == 0 {
 		return PeriodicInput(provider.PeriodicGetter)
 	}

--- a/pkg/keyvisual/input/input.go
+++ b/pkg/keyvisual/input/input.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/log"
+
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/keyvisual/region"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/keyvisual/storage"
 )
@@ -30,6 +32,9 @@ type StatInput interface {
 
 func NewStatInput(provider *region.DataProvider) StatInput {
 	if provider.FileStartTime == 0 && provider.FileEndTime == 0 {
+		if provider.PeriodicGetter == nil {
+			log.Fatal("Empty DataProvider is not allowed")
+		}
 		return PeriodicInput(provider.PeriodicGetter)
 	}
 	startTime := time.Unix(provider.FileStartTime, 0)

--- a/pkg/keyvisual/region/interface.go
+++ b/pkg/keyvisual/region/interface.go
@@ -13,10 +13,6 @@
 
 package region
 
-import (
-	"go.etcd.io/etcd/clientv3"
-)
-
 type RegionsInfo interface {
 	Len() int
 	GetKeys() []string
@@ -25,13 +21,11 @@ type RegionsInfo interface {
 
 type RegionsInfoGenerator func() (RegionsInfo, error)
 
-type PDDataProvider struct {
+type DataProvider struct {
 	// File mode (debug)
 	FileStartTime int64
 	FileEndTime   int64
 	// API or Core mode
 	// This item takes effect only when both FileStartTime and FileEndTime are 0.
 	PeriodicGetter RegionsInfoGenerator
-
-	EtcdClient *clientv3.Client
 }

--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -303,8 +303,8 @@ func (s *Service) heatmaps(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-func (s *Service) provideLocals() (*config.Config, *clientv3.Client, *dbstore.DB, *tidb.Forwarder) {
-	return s.config, s.etcdClient, s.db, s.forwarder
+func (s *Service) provideLocals() (*config.Config, *clientv3.Client, *pd.Client, *dbstore.DB, *tidb.Forwarder) {
+	return s.config, s.etcdClient, s.pdClient, s.db, s.forwarder
 }
 
 func newWaitGroup(lc fx.Lifecycle) *sync.WaitGroup {

--- a/pkg/keyvisual/storage/stat.go
+++ b/pkg/keyvisual/storage/stat.go
@@ -183,13 +183,11 @@ type Stat struct {
 	keyMap   matrix.KeyMap
 	strategy matrix.Strategy
 
-	provider *region.PDDataProvider
-
 	db *dbstore.DB
 }
 
 // NewStat generates a Stat based on the configuration.
-func NewStat(lc fx.Lifecycle, wg *sync.WaitGroup, provider *region.PDDataProvider, db *dbstore.DB, cfg StatConfig, strategy matrix.Strategy, startTime time.Time) *Stat {
+func NewStat(lc fx.Lifecycle, wg *sync.WaitGroup, db *dbstore.DB, cfg StatConfig, strategy matrix.Strategy, startTime time.Time) *Stat {
 	layers := make([]*layerStat, len(cfg.LayersConfig))
 	for i, c := range cfg.LayersConfig {
 		layers[i] = newLayerStat(uint8(i), c, strategy, startTime, db)
@@ -200,7 +198,6 @@ func NewStat(lc fx.Lifecycle, wg *sync.WaitGroup, provider *region.PDDataProvide
 	s := &Stat{
 		layers:   layers,
 		strategy: strategy,
-		provider: provider,
 		db:       db,
 	}
 

--- a/pkg/pd/http_client.go
+++ b/pkg/pd/http_client.go
@@ -15,6 +15,7 @@ package pd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -50,7 +51,7 @@ func NewPDClient(lc fx.Lifecycle, httpClient *http.Client, config *config.Config
 }
 
 func (pd *Client) SendGetRequest(path string) ([]byte, error) {
-	uri := pd.address + path
+	uri := fmt.Sprintf("%s/pd/api/v1%s", pd.address, path)
 	req, err := http.NewRequestWithContext(pd.lifecycleCtx, "GET", uri, nil)
 	if err != nil {
 		return nil, ErrPDClientRequestFailed.Wrap(err, "failed to build request for PD API %s", path)

--- a/pkg/pd/http_client.go
+++ b/pkg/pd/http_client.go
@@ -28,15 +28,15 @@ var (
 )
 
 type Client struct {
-	endpointAddr string
+	address      string
 	httpClient   *http.Client
 	lifecycleCtx context.Context
 }
 
 func NewPDClient(lc fx.Lifecycle, httpClient *http.Client, config *config.Config) *Client {
 	client := &Client{
-		httpClient:   httpClient,
-		endpointAddr: config.PDEndPoint,
+		httpClient: httpClient,
+		address:    config.PDEndPoint,
 	}
 
 	lc.Append(fx.Hook{
@@ -50,7 +50,7 @@ func NewPDClient(lc fx.Lifecycle, httpClient *http.Client, config *config.Config
 }
 
 func (pd *Client) SendRequest(path string) ([]byte, error) {
-	uri := pd.endpointAddr + path
+	uri := pd.address + path
 	req, err := http.NewRequestWithContext(pd.lifecycleCtx, "GET", uri, nil)
 	if err != nil {
 		return nil, ErrPDClientRequestFailed.Wrap(err, "failed to build request for PD API %s", path)

--- a/pkg/pd/http_client.go
+++ b/pkg/pd/http_client.go
@@ -49,7 +49,7 @@ func NewPDClient(lc fx.Lifecycle, httpClient *http.Client, config *config.Config
 	return client
 }
 
-func (pd *Client) SendRequest(path string) ([]byte, error) {
+func (pd *Client) SendGetRequest(path string) ([]byte, error) {
 	uri := pd.address + path
 	req, err := http.NewRequestWithContext(pd.lifecycleCtx, "GET", uri, nil)
 	if err != nil {

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -13,6 +13,8 @@
 
 package pd
 
-import "github.com/joomcode/errorx"
+import (
+	"github.com/joomcode/errorx"
+)
 
 var ErrNS = errorx.NewNamespace("error.pd")

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -17,4 +17,6 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-var ErrNS = errorx.NewNamespace("error.pd")
+var (
+	ErrNS = errorx.NewNamespace("error.pd")
+)

--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -16,7 +16,9 @@ package tidb
 import (
 	"database/sql/driver"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -35,13 +37,10 @@ const (
 )
 
 var (
-	ErrTiDBConnFailed = ErrNS.NewType("tidb_conn_failed")
-	ErrTiDBAuthFailed = ErrNS.NewType("tidb_auth_failed")
+	ErrTiDBConnFailed          = ErrNS.NewType("tidb_conn_failed")
+	ErrTiDBAuthFailed          = ErrNS.NewType("tidb_auth_failed")
+	ErrTiDBClientRequestFailed = ErrNS.NewType("client_request_failed")
 )
-
-func (f *Forwarder) GetDBConnProps() (string, int) {
-	return "127.0.0.1", f.tidbPort
-}
 
 func (f *Forwarder) GetStatusConnProps() (string, int) {
 	return "127.0.0.1", f.statusPort
@@ -51,8 +50,7 @@ func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	var addr string
 	addr = os.Getenv(envTidbOverrideEndpointKey)
 	if len(addr) < 1 {
-		host, port := f.GetDBConnProps()
-		addr = fmt.Sprintf("%s:%d", host, port)
+		addr = fmt.Sprintf("127.0.0.1:%d", f.tidbPort)
 	}
 	dsnConfig := mysql.NewConfig()
 	dsnConfig.Net = "tcp"
@@ -84,4 +82,28 @@ func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+
+func (f *Forwarder) SendGetRequest(path string) ([]byte, error) {
+	uri := fmt.Sprintf("%s://127.0.0.1:%d%s", f.uriScheme, f.statusPort, path)
+	req, err := http.NewRequestWithContext(f.lifecycleCtx, "GET", uri, nil)
+	if err != nil {
+		return nil, ErrTiDBClientRequestFailed.Wrap(err, "failed to build request for TiDB API %s", path)
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, ErrTiDBClientRequestFailed.Wrap(err, "failed to send request to TiDB API %s", path)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrTiDBClientRequestFailed.New("received non success status code %d from TiDB API %s", resp.StatusCode, path)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, ErrTiDBClientRequestFailed.Wrap(err, "failed to read response from TiDB API %s", path)
+	}
+
+	return data, nil
 }

--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -42,10 +42,6 @@ var (
 	ErrTiDBClientRequestFailed = ErrNS.NewType("client_request_failed")
 )
 
-func (f *Forwarder) GetStatusConnProps() (string, int) {
-	return "127.0.0.1", f.statusPort
-}
-
 func (f *Forwarder) OpenTiDB(user string, pass string) (*gorm.DB, error) {
 	var addr string
 	addr = os.Getenv(envTidbOverrideEndpointKey)

--- a/pkg/tidb/conn.go
+++ b/pkg/tidb/conn.go
@@ -34,6 +34,11 @@ const (
 	envTidbOverrideEndpointKey = "TIDB_OVERRIDE_ENDPOINT"
 )
 
+var (
+	ErrTiDBConnFailed = ErrNS.NewType("tidb_conn_failed")
+	ErrTiDBAuthFailed = ErrNS.NewType("tidb_auth_failed")
+)
+
 func (f *Forwarder) GetDBConnProps() (string, int) {
 	return "127.0.0.1", f.tidbPort
 }

--- a/pkg/tidb/forwarder.go
+++ b/pkg/tidb/forwarder.go
@@ -33,6 +33,11 @@ import (
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/pd"
 )
 
+var (
+	ErrPDAccessFailed = ErrNS.NewType("pd_access_failed")
+	ErrNoAliveTiDB    = ErrNS.NewType("no_alive_tidb")
+)
+
 type tidbServerInfo struct {
 	ID         string `json:"ddl_id"`
 	IP         string `json:"ip"`

--- a/pkg/tidb/tidb.go
+++ b/pkg/tidb/tidb.go
@@ -17,4 +17,6 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-var ErrNS = errorx.NewNamespace("error.tidb")
+var (
+	ErrNS = errorx.NewNamespace("error.tidb")
+)

--- a/pkg/tidb/tidb.go
+++ b/pkg/tidb/tidb.go
@@ -17,10 +17,4 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-var (
-	ErrorNS           = errorx.NewNamespace("error.tidb")
-	ErrPDAccessFailed = ErrorNS.NewType("pd_access_failed")
-	ErrNoAliveTiDB    = ErrorNS.NewType("no_alive_tidb")
-	ErrTiDBConnFailed = ErrorNS.NewType("tidb_conn_failed")
-	ErrTiDBAuthFailed = ErrorNS.NewType("tidb_auth_failed")
-)
+var ErrNS = errorx.NewNamespace("error.tidb")

--- a/pkg/utils/topology/pd.go
+++ b/pkg/utils/topology/pd.go
@@ -30,7 +30,7 @@ func FetchPDTopology(pdClient *pd.Client) ([]PDInfo, error) {
 		return nil, err
 	}
 
-	data, err := pdClient.SendRequest("/pd/api/v1/members")
+	data, err := pdClient.SendGetRequest("/pd/api/v1/members")
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func FetchPDTopology(pdClient *pd.Client) ([]PDInfo, error) {
 }
 
 func fetchPDStartTimestamp(pdClient *pd.Client) (int64, error) {
-	data, err := pdClient.SendRequest("/pd/api/v1/status")
+	data, err := pdClient.SendGetRequest("/pd/api/v1/status")
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +112,7 @@ func fetchPDStartTimestamp(pdClient *pd.Client) (int64, error) {
 }
 
 func fetchPDHealth(pdClient *pd.Client) (map[uint64]struct{}, error) {
-	data, err := pdClient.SendRequest("/pd/api/v1/health")
+	data, err := pdClient.SendGetRequest("/pd/api/v1/health")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/topology/pd.go
+++ b/pkg/utils/topology/pd.go
@@ -30,7 +30,7 @@ func FetchPDTopology(pdClient *pd.Client) ([]PDInfo, error) {
 		return nil, err
 	}
 
-	data, err := pdClient.SendGetRequest("/pd/api/v1/members")
+	data, err := pdClient.SendGetRequest("/members")
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func FetchPDTopology(pdClient *pd.Client) ([]PDInfo, error) {
 }
 
 func fetchPDStartTimestamp(pdClient *pd.Client) (int64, error) {
-	data, err := pdClient.SendGetRequest("/pd/api/v1/status")
+	data, err := pdClient.SendGetRequest("/status")
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +112,7 @@ func fetchPDStartTimestamp(pdClient *pd.Client) (int64, error) {
 }
 
 func fetchPDHealth(pdClient *pd.Client) (map[uint64]struct{}, error) {
-	data, err := pdClient.SendGetRequest("/pd/api/v1/health")
+	data, err := pdClient.SendGetRequest("/health")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/topology/store.go
+++ b/pkg/utils/topology/store.go
@@ -105,7 +105,7 @@ type store struct {
 }
 
 func fetchStores(pdClient *pd.Client) ([]store, error) {
-	data, err := pdClient.SendGetRequest("/pd/api/v1/stores")
+	data, err := pdClient.SendGetRequest("/stores")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/topology/store.go
+++ b/pkg/utils/topology/store.go
@@ -105,7 +105,7 @@ type store struct {
 }
 
 func fetchStores(pdClient *pd.Client) ([]store, error) {
-	data, err := pdClient.SendRequest("/pd/api/v1/stores")
+	data, err := pdClient.SendGetRequest("/pd/api/v1/stores")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* *: rename some `ctx` to `lifecycleCtx`
* pd: pd http client will automatically complete the `/pd/api/v1` prefix
* tidb: support `SendGetRequest` like `pd.Client` to handle `ctx` automatically
* keyviz: 
  * use pd and tidb client to send request
  * refactor `region.DataProvider`, remove logic related to pd

**Note**: Need to update PD code.