### PR TITLE
fix Descriptions.Item has different look between Chrome and Safari

### DIFF
--- a/ui/lib/antd.override.less
+++ b/ui/lib/antd.override.less
@@ -17,3 +17,12 @@
 .ant-tooltip {
   pointer-events: none;
 }
+
+// related issue:
+// Descriptions component has different look between Chrome and Safari
+// https://github.com/ant-design/ant-design/issues/24999
+// can be removed after above issue is fixed
+th.ant-descriptions-item,
+th.ant-descriptions-item-label {
+  text-align: left;
+}


### PR DESCRIPTION
Before:

![企业微信20200615104131](https://user-images.githubusercontent.com/1284531/84671400-ec527b00-af59-11ea-8524-d8456b5d3161.png)

![企业微信20200615104157](https://user-images.githubusercontent.com/1284531/84671408-ee1c3e80-af59-11ea-9c52-d363234cb335.png)

![企业微信20200615104208](https://user-images.githubusercontent.com/1284531/84671412-eeb4d500-af59-11ea-9780-57896f5bf025.png)

After:

![企业微信20200615104230](https://user-images.githubusercontent.com/1284531/84671585-258aeb00-af5a-11ea-9a59-03dc58fb262d.png)

![企业微信20200615104245](https://user-images.githubusercontent.com/1284531/84671595-2754ae80-af5a-11ea-96e6-5f6a582a5d72.png)

![企业微信20200615104256](https://user-images.githubusercontent.com/1284531/84671598-2885db80-af5a-11ea-97a0-a850811e91e3.png)
