### PR TITLE
telemetry: assign the customized API host when initiating the mixpanel

### DIFF
--- a/ui/lib/utils/telemetry.ts
+++ b/ui/lib/utils/telemetry.ts
@@ -7,7 +7,7 @@ export { mixpanel }
 export async function init() {
   const token =
     process.env.REACT_APP_MIXPANEL_TOKEN || '00000000000000000000000000000000'
-  mixpanel.init(token, {
+  let options = {
     autotrack: false,
     opt_out_tracking_by_default: true,
     batch_requests: true,
@@ -18,13 +18,12 @@ export async function init() {
       '$referrer',
       '$referring_domain',
     ],
-  })
-  const customApiHost = process.env.REACT_APP_MIXPANEL_HOST
-  if (customApiHost) {
-    mixpanel.set_config({
-      api_host: customApiHost,
-    })
   }
+  const apiHost = process.env.REACT_APP_MIXPANEL_HOST
+  if (apiHost) {
+    options['api_host'] = apiHost
+  }
+  mixpanel.init(token, options)
   // disable mixpanel to report data immediately
   mixpanel.opt_out_tracking()
   const res = await client.getInstance().getInfo()


### PR DESCRIPTION
close #655

If there are remaining data were not sent out last time, mixpanel will send them out immediately when initiating. So we should assign the customized API host when initiating, else mixpanel will send the remaining data to the default API host before changing it.

Before:

![企业微信20200623012414](https://user-images.githubusercontent.com/1284531/85364641-26bda880-b556-11ea-9ed1-1355f8cd9b2b.png)

![企业微信20200623012334](https://user-images.githubusercontent.com/1284531/85364657-3210d400-b556-11ea-88b4-ae1b389889ff.png)

After:

![企业微信20200623013919](https://user-images.githubusercontent.com/1284531/85365154-53be8b00-b557-11ea-8007-c9682cdf1ea0.png)



