### PR TITLE
Docs : Add environment variable declare step in  Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Declare the global environment variable:
    > After the installation, TiUP displays the absolute path of the corresponding `profile` file. You need to modify the following `source` command according to the path.
 
 ```bash
-source .bash_profile
+source ~/.bash_profile
 ```
 
 Start a local TiDB cluster:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,16 @@ Download and install TiUP:
 curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
 ```
 
+Declare the global environment variable:
+
+   > **Note:**
+   >
+   > After the installation, TiUP displays the absolute path of the corresponding `profile` file. You need to modify the following `source` command according to the path.
+
+```bash
+source .bash_profile
+```
+
 Start a local TiDB cluster:
 
 ```bash


### PR DESCRIPTION
## Why for change 
When following the contribute docs to set the development workspace, i found the step of environment variable declare is missed and get the warning that `Command 'tiup' not found`.

## What did i do
I update the contribute docs and add the required step. 

## Test
No code change 

## Impact
No impact