### PR TITLE
Update search

### DIFF
--- a/pkg/apiserver/logsearch/service.go
+++ b/pkg/apiserver/logsearch/service.go
@@ -74,16 +74,20 @@ func NewService(lc fx.Lifecycle, config *config.Config, db *dbstore.DB) *Service
 
 func Register(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 	endpoint := r.Group("/logs")
-
-	endpoint.GET("/download", s.DownloadLogs)
-	endpoint.GET("/download/acquire_token", auth.MWAuthRequired(), s.GetDownloadToken)
-	endpoint.PUT("/taskgroup", auth.MWAuthRequired(), s.CreateTaskGroup)
-	endpoint.GET("/taskgroups", auth.MWAuthRequired(), s.GetAllTaskGroups)
-	endpoint.GET("/taskgroups/:id", auth.MWAuthRequired(), s.GetTaskGroup)
-	endpoint.GET("/taskgroups/:id/preview", auth.MWAuthRequired(), s.GetTaskGroupPreview)
-	endpoint.POST("/taskgroups/:id/retry", auth.MWAuthRequired(), s.RetryTask)
-	endpoint.POST("/taskgroups/:id/cancel", auth.MWAuthRequired(), s.CancelTask)
-	endpoint.DELETE("/taskgroups/:id", auth.MWAuthRequired(), s.DeleteTaskGroup)
+	{
+		endpoint.GET("/download", s.DownloadLogs)
+		endpoint.Use(auth.MWAuthRequired())
+		{
+			endpoint.GET("/download/acquire_token", s.GetDownloadToken)
+			endpoint.PUT("/taskgroup", s.CreateTaskGroup)
+			endpoint.GET("/taskgroups", s.GetAllTaskGroups)
+			endpoint.GET("/taskgroups/:id", s.GetTaskGroup)
+			endpoint.GET("/taskgroups/:id/preview", s.GetTaskGroupPreview)
+			endpoint.POST("/taskgroups/:id/retry", s.RetryTask)
+			endpoint.POST("/taskgroups/:id/cancel", s.CancelTask)
+			endpoint.DELETE("/taskgroups/:id", s.DeleteTaskGroup)
+		}
+	}
 }
 
 type CreateTaskGroupRequest struct {

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -150,12 +150,16 @@ func QuerySlowLogList(db *gorm.DB, req *GetListRequest) ([]Base, error) {
 
 	if req.Text != "" {
 		lowerStr := strings.ToLower(req.Text)
-		tx = tx.Where("txn_start_ts REGEXP ? OR LOWER(digest) REGEXP ? OR LOWER(CONVERT(prev_stmt USING utf8)) REGEXP ? OR LOWER(CONVERT(query USING utf8)) REGEXP ?",
-			lowerStr,
-			lowerStr,
-			lowerStr,
-			lowerStr,
-		)
+		arr := strings.Fields(lowerStr)
+		for _, v := range arr {
+			tx = tx.Where(
+				`txn_start_ts REGEXP ?
+				 OR LOWER(digest) REGEXP ?
+				 OR LOWER(CONVERT(prev_stmt USING utf8)) REGEXP ?
+				 OR LOWER(CONVERT(query USING utf8)) REGEXP ?`,
+				v, v, v, v,
+			)
+		}
 	}
 
 	if len(req.DB) > 0 {

--- a/pkg/apiserver/statement/queries.go
+++ b/pkg/apiserver/statement/queries.go
@@ -176,14 +176,17 @@ func QueryStatementsOverview(
 
 	if len(text) > 0 {
 		lowerText := strings.ToLower(text)
-		query = query.Where(
-			`LOWER(digest_text) REGEXP ?
-			 OR LOWER(digest) REGEXP ?
-			 OR LOWER(schema_name) REGEXP ?
-			 OR LOWER(table_names) REGEXP ?
-			 OR LOWER(plan) REGEXP ?`,
-			lowerText, lowerText, lowerText, lowerText, lowerText,
-		)
+		arr := strings.Fields(lowerText)
+		for _, v := range arr {
+			query = query.Where(
+				`LOWER(digest_text) REGEXP ?
+				 OR LOWER(digest) REGEXP ?
+				 OR LOWER(schema_name) REGEXP ?
+				 OR LOWER(table_names) REGEXP ?
+				 OR LOWER(plan) REGEXP ?`,
+				v, v, v, v, v,
+			)
+		}
 	}
 
 	err = query.Find(&result).Error


### PR DESCRIPTION
close #676 

- Keep consistent search behaviors for log search, statements, and slow queries.

Before:

![企业微信20200713034740](https://user-images.githubusercontent.com/1284531/87281503-e1254780-c525-11ea-8cb2-99b65e8d3b88.png)

After:

![企业微信20200713034655](https://user-images.githubusercontent.com/1284531/87281541-e8e4ec00-c525-11ea-94f9-8cc5ffcf60e8.png)
