### PR TITLE
Rename disable_telemetry to enable_telemetry

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -71,7 +71,7 @@ func NewCLIConfig() *DashboardCLIConfig {
 	flag.StringVar(&cfg.CoreConfig.DataDir, "data-dir", "/tmp/dashboard-data", "path to the Dashboard Server data directory")
 	flag.StringVar(&cfg.CoreConfig.PublicPathPrefix, "path-prefix", config.DefaultPublicPathPrefix, "public URL path prefix for reverse proxies")
 	flag.StringVar(&cfg.CoreConfig.PDEndPoint, "pd", "http://127.0.0.1:2379", "PD endpoint address that Dashboard Server connects to")
-	flag.BoolVar(&cfg.CoreConfig.DisableTelemetry, "disable-telemetry", false, "disable client to report data")
+	flag.BoolVar(&cfg.CoreConfig.EnableTelemetry, "enable-telemetry", true, "enable client to report data for analysis")
 
 	showVersion := flag.BoolP("version", "v", false, "print version information and exit")
 

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -48,7 +48,6 @@ func Register(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 
 type InfoResponse struct { //nolint:golint
 	Version         *version.Info `json:"version"`
-	PDEndPoint      string        `json:"pd_end_point"`
 	EnableTelemetry bool          `json:"enable_telemetry"`
 }
 
@@ -63,7 +62,6 @@ type InfoResponse struct { //nolint:golint
 func (s *Service) infoHandler(c *gin.Context) {
 	resp := InfoResponse{
 		Version:         version.GetInfo(),
-		PDEndPoint:      s.config.PDEndPoint,
 		EnableTelemetry: s.config.EnableTelemetry,
 	}
 	c.JSON(http.StatusOK, resp)

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -47,9 +47,9 @@ func Register(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 }
 
 type InfoResponse struct { //nolint:golint
-	Version          *version.Info `json:"version"`
-	PDEndPoint       string        `json:"pd_end_point"`
-	DisableTelemetry bool          `json:"disable_telemetry"`
+	Version         *version.Info `json:"version"`
+	PDEndPoint      string        `json:"pd_end_point"`
+	EnableTelemetry bool          `json:"enable_telemetry"`
 }
 
 // @Summary Dashboard info
@@ -62,9 +62,9 @@ type InfoResponse struct { //nolint:golint
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) infoHandler(c *gin.Context) {
 	resp := InfoResponse{
-		Version:          version.GetInfo(),
-		PDEndPoint:       s.config.PDEndPoint,
-		DisableTelemetry: s.config.DisableTelemetry,
+		Version:         version.GetInfo(),
+		PDEndPoint:      s.config.PDEndPoint,
+		EnableTelemetry: s.config.EnableTelemetry,
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,8 +39,8 @@ type Config struct {
 	// TLS config for mTLS authentication between TiDB and MySQL client.
 	TiDBTLSConfig *tls.Config
 
-	// Disable client to report data for analysis
-	DisableTelemetry bool
+	// enable client to report data for analysis
+	EnableTelemetry bool
 }
 
 func (c *Config) NormalizePDEndPoint() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// TLS config for mTLS authentication between TiDB and MySQL client.
 	TiDBTLSConfig *tls.Config
 
-	// enable client to report data for analysis
+	// Enable client to report data for analysis
 	EnableTelemetry bool
 }
 

--- a/ui/lib/utils/telemetry.ts
+++ b/ui/lib/utils/telemetry.ts
@@ -26,7 +26,7 @@ export async function init(info: InfoInfoResponse) {
   mixpanel.init(token, options)
   // disable mixpanel to report data immediately
   mixpanel.opt_out_tracking()
-  if (info?.disable_telemetry === false) {
+  if (info?.enable_telemetry) {
     mixpanel.register({
       $current_url: getPathInLocationHash(),
     })


### PR DESCRIPTION
* config: rename `disable_telemetry` to `enable_telemetry`
* ui: rename `disable_telemetry` to `enable_telemetry`
* info: remove the useless `pd_end_point` that should not be returned

partially solve #670 
