### PR TITLE
build(deps): sql-formatter-plus-plus -> sql-formatter-plus

### DIFF
--- a/ui/lib/utils/formatSql.ts
+++ b/ui/lib/utils/formatSql.ts
@@ -1,4 +1,4 @@
-import sqlFormatter from 'sql-formatter-plus-plus'
+import sqlFormatter from 'sql-formatter-plus'
 
 export default function formatSql(sql?: string): string {
   return sqlFormatter.format(sql || '', { uppercase: true })

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,7 @@
     "react-use": "^14.2.0",
     "single-spa": "^5.3.4",
     "single-spa-react": "^2.14.0",
-    "sql-formatter-plus-plus": "^1.4.0",
+    "sql-formatter-plus": "^1.3.6",
     "string-template": "^1.0.0"
   },
   "scripts": {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1580,10 +1580,10 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/polyfill@^7.7.0":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.8.7.tgz#151ec24c7135481336168c3bd8b8bf0cf91c032f"
-  integrity sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==
+"@babel/polyfill@^7.6.0":
+  version "7.10.4"
+  resolved "https://registry.npm.taobao.org/@babel/polyfill/download/@babel/polyfill-7.10.4.tgz?cache=0&sync_timestamp=1593521152048&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Fpolyfill%2Fdownload%2F%40babel%2Fpolyfill-7.10.4.tgz#915e5bfe61490ac0199008e35ca9d7d151a8e45a"
+  integrity sha1-kV5b/mFJCsAZkAjjXKnX0VGo5Fo=
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.4"
@@ -15700,14 +15700,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql-formatter-plus-plus@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/sql-formatter-plus-plus/-/sql-formatter-plus-plus-1.4.0.tgz#e7b329ed572a4b804fd7f8ceb9960811af0b8656"
-  integrity sha512-AEXMcq+jwTTS/Ol1cD83eSRMdJje6yb5vWOFtl0drF9sGl7yVjc7tmJnDWaLStAOcalv/9BIk/91KKcw++ZjOA==
+sql-formatter-plus@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.npm.taobao.org/sql-formatter-plus/download/sql-formatter-plus-1.3.6.tgz#56e671181ff34c0dc403bac6f950486626f9d406"
+  integrity sha1-VuZxGB/zTA3EA7rG+VBIZib51AY=
   dependencies:
-    "@babel/polyfill" "^7.7.0"
+    "@babel/polyfill" "^7.6.0"
     lodash "^4.17.15"
-    regexpu-core "^4.7.0"
 
 sshpk@^1.7.0:
   version "1.16.1"


### PR DESCRIPTION
Revert parts of https://github.com/pingcap-incubator/tidb-dashboard/pull/489

Latest Firefox stable release has supported [Unicode property escapes](https://caniuse.com/#search=Unicode%20property%20escapes)

Signed-off-by: TennyZhuang <zty0826@gmail.com>