### PR TITLE
ui: improve the expansion and collapse of sider menu

### DIFF
--- a/ui/dashboardApp/layout/main/Sider/Banner.tsx
+++ b/ui/dashboardApp/layout/main/Sider/Banner.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from 'react'
-import { MenuUnfoldOutlined, MenuFoldOutlined } from '@ant-design/icons'
+import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons'
 import { useSize } from '@umijs/hooks'
 import Flexbox from '@g07cha/flexbox-react'
-import { useSpring, animated } from 'react-spring'
 import { useClientRequest } from '@lib/utils/useClientRequest'
 import client, { InfoInfoResponse } from '@lib/client'
 
@@ -46,14 +45,14 @@ export default function ToggleBanner({
   onToggle,
 }) {
   const [bannerSize, bannerRef] = useSize<HTMLDivElement>()
-  const transBanner = useSpring({
+  const bannerStyle = {
     opacity: collapsed ? 0 : 1,
     height: collapsed ? toggleHeight : bannerSize.height || 0,
-  })
-  const transButton = useSpring({
+  }
+  const buttonStyle = {
     left: collapsed ? 0 : fullWidth - toggleWidth,
     width: collapsed ? collapsedWidth : toggleWidth,
-  })
+  }
 
   const { data, isLoading } = useClientRequest((reqConfig) =>
     client.getInstance().infoGet(reqConfig)
@@ -68,10 +67,7 @@ export default function ToggleBanner({
 
   return (
     <div className={styles.banner} onClick={onToggle}>
-      <animated.div
-        style={transBanner}
-        className={styles.bannerLeftAnimationWrapper}
-      >
+      <div style={bannerStyle}>
         <div
           ref={bannerRef}
           className={styles.bannerLeft}
@@ -90,14 +86,14 @@ export default function ToggleBanner({
             </div>
           </Flexbox>
         </div>
-      </animated.div>
-      <animated.div style={transButton} className={styles.bannerRight}>
+      </div>
+      <div style={buttonStyle} className={styles.bannerRight}>
         {collapsed ? (
           <MenuUnfoldOutlined style={{ margin: 'auto' }} />
         ) : (
           <MenuFoldOutlined style={{ margin: 'auto' }} />
         )}
-      </animated.div>
+      </div>
     </div>
   )
 }

--- a/ui/dashboardApp/layout/main/Sider/index.module.less
+++ b/ui/dashboardApp/layout/main/Sider/index.module.less
@@ -2,10 +2,11 @@
 
 @sider-background: #f7f7fa;
 
+.wrapper {
+  transition: width 444ms ease;
+}
+
 .sider {
-  position: fixed;
-  left: 0;
-  top: 0;
   height: 100%;
   z-index: 1;
   background: linear-gradient(@sider-background, #ebeffa);

--- a/ui/dashboardApp/layout/main/Sider/index.tsx
+++ b/ui/dashboardApp/layout/main/Sider/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { BugOutlined, ExperimentOutlined } from '@ant-design/icons'
 import { Layout, Menu } from 'antd'
 import { Link } from 'react-router-dom'
@@ -35,6 +35,12 @@ function useActiveAppId(registry) {
     }
   })
   return appId
+}
+
+function triggerResizeEvent() {
+  const event = document.createEvent('HTMLEvents')
+  event.initEvent('resize', true, false)
+  window.dispatchEvent(event)
 }
 
 function Sider({
@@ -127,8 +133,17 @@ function Sider({
     }
   }, [defaultCollapsed])
 
+  const wrapperRef = useCallback((wrapper) => {
+    if (wrapper !== null) {
+      wrapper.addEventListener('transitionend', (e) => {
+        if (e.target !== wrapper || e.propertyName !== 'width') return
+        triggerResizeEvent()
+      })
+    }
+  }, [])
+
   return (
-    <div className={styles.wrapper} style={siderStyle}>
+    <div className={styles.wrapper} style={siderStyle} ref={wrapperRef}>
       <Layout.Sider
         className={styles.sider}
         width={fullWidth}

--- a/ui/dashboardApp/layout/main/Sider/index.tsx
+++ b/ui/dashboardApp/layout/main/Sider/index.tsx
@@ -17,10 +17,9 @@ function useAppMenuItem(registry, appId, title?: string) {
     return null
   }
   return (
-    <Menu.Item key={appId}>
+    <Menu.Item key={appId} icon={app.icon ? <app.icon /> : null}>
       <Link to={app.indexRoute} id={appId}>
-        {app.icon ? <app.icon /> : null}
-        <span>{title ? title : t(`${appId}.nav_title`, appId)}</span>
+        {title ? title : t(`${appId}.nav_title`, appId)}
       </Link>
     </Menu.Item>
   )
@@ -66,12 +65,8 @@ function Sider({
   const debugSubMenu = (
     <Menu.SubMenu
       key="debug"
-      title={
-        <span>
-          <BugOutlined />
-          <span>{t('nav.sider.debug')}</span>
-        </span>
-      }
+      icon={<BugOutlined />}
+      title={t('nav.sider.debug')}
     >
       {debugSubMenuItems}
     </Menu.SubMenu>
@@ -84,12 +79,8 @@ function Sider({
   const experimentalSubMenu = (
     <Menu.SubMenu
       key="experimental"
-      title={
-        <span>
-          <ExperimentOutlined />
-          <span>{t('nav.sider.experimental')}</span>
-        </span>
-      }
+      icon={<ExperimentOutlined />}
+      title={t('nav.sider.experimental')}
     >
       {experimentalSubMenuItems}
     </Menu.SubMenu>
@@ -162,7 +153,7 @@ function Sider({
         />
         <Menu
           subMenuOpenDelay={animationDelay}
-          subMenuCloseDelay={animationDelay}
+          subMenuCloseDelay={animationDelay + 0.1}
           mode="inline"
           selectedKeys={[activeAppId]}
           style={{ flexGrow: 1 }}
@@ -171,8 +162,8 @@ function Sider({
           {menuItems}
         </Menu>
         <Menu
-          subMenuOpenDelay={animationDelay + 200}
-          subMenuCloseDelay={animationDelay + 200}
+          subMenuOpenDelay={animationDelay}
+          subMenuCloseDelay={animationDelay}
           mode="inline"
           selectedKeys={[activeAppId]}
         >

--- a/ui/dashboardApp/layout/main/Sider/index.tsx
+++ b/ui/dashboardApp/layout/main/Sider/index.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useMemo } from 'react'
-import { ExperimentOutlined, BugOutlined } from '@ant-design/icons'
+import React, { useMemo, useState } from 'react'
+import { BugOutlined, ExperimentOutlined } from '@ant-design/icons'
 import { Layout, Menu } from 'antd'
 import { Link } from 'react-router-dom'
 import { useEventListener } from '@umijs/hooks'
 import { useTranslation } from 'react-i18next'
-import { useSpring, animated } from 'react-spring'
 import client from '@lib/client'
 
 import Banner from './Banner'
@@ -116,9 +115,9 @@ function Sider({
     useAppMenuItem(registry, 'user_profile', displayName),
   ]
 
-  const transSider = useSpring({
+  const siderStyle = {
     width: collapsed ? collapsedWidth : fullWidth,
-  })
+  }
 
   const defaultOpenKeys = useMemo(() => {
     if (defaultCollapsed) {
@@ -129,7 +128,7 @@ function Sider({
   }, [defaultCollapsed])
 
   return (
-    <animated.div style={transSider}>
+    <div className={styles.wrapper} style={siderStyle}>
       <Layout.Sider
         className={styles.sider}
         width={fullWidth}
@@ -165,7 +164,7 @@ function Sider({
           {extraMenuItems}
         </Menu>
       </Layout.Sider>
-    </animated.div>
+    </div>
   )
 }
 

--- a/ui/dashboardApp/layout/main/index.module.less
+++ b/ui/dashboardApp/layout/main/index.module.less
@@ -1,14 +1,28 @@
 @import '~antd/es/style/themes/default.less';
 
 .container {
+  display: flex;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
   height: 100vh;
+  width: 100vw;
 }
 
 .content {
   position: relative;
+
+  flex: 1;
+
   z-index: 3;
   background: #fff;
   min-height: 100vh;
+  box-shadow: 0 0 30px rgba(#000, 0.15);
+
+  overflow-x: hidden;
+  overflow-y: auto;
 
   &:before,
   &:after {
@@ -16,14 +30,4 @@
     content: ' ';
     display: table;
   }
-}
-
-.contentBack {
-  position: fixed;
-  z-index: 2;
-  background: #fff;
-  top: 0;
-  height: 100%;
-  right: 0;
-  box-shadow: 0 0 30px rgba(#000, 0.15);
 }

--- a/ui/dashboardApp/layout/main/index.tsx
+++ b/ui/dashboardApp/layout/main/index.tsx
@@ -1,45 +1,14 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Root } from '@lib/components'
 import { useLocalStorageState } from '@umijs/hooks'
 import { HashRouter as Router } from 'react-router-dom'
-import { useSpring, animated } from 'react-spring'
+import { animated, useSpring } from 'react-spring'
 
 import Sider from './Sider'
 import styles from './index.module.less'
 
 const siderWidth = 260
 const siderCollapsedWidth = 80
-const collapsedContentOffset = siderCollapsedWidth - siderWidth
-const contentOffsetTrigger = collapsedContentOffset * 0.99
-
-function triggerResizeEvent() {
-  const event = document.createEvent('HTMLEvents')
-  event.initEvent('resize', true, false)
-  window.dispatchEvent(event)
-}
-
-const useContentLeftOffset = (collapsed) => {
-  const [offset, setOffset] = useState(siderWidth)
-  const onAnimationStart = useCallback(() => {
-    if (!collapsed) {
-      setOffset(siderWidth)
-    }
-  }, [collapsed])
-  const onAnimationFrame = useCallback(
-    ({ x }) => {
-      if (collapsed && x < contentOffsetTrigger) {
-        setOffset(siderCollapsedWidth)
-      }
-    },
-    [collapsed]
-  )
-  useEffect(triggerResizeEvent, [offset])
-  return {
-    contentLeftOffset: offset,
-    onAnimationStart,
-    onAnimationFrame,
-  }
-}
 
 export default function App({ registry }) {
   const [collapsed, setCollapsed] = useLocalStorageState(
@@ -47,16 +16,6 @@ export default function App({ registry }) {
     false
   )
   const [defaultCollapsed] = useState(collapsed)
-  const {
-    contentLeftOffset,
-    onAnimationStart,
-    onAnimationFrame,
-  } = useContentLeftOffset(collapsed)
-  const transContentBack = useSpring({
-    x: collapsed ? collapsedContentOffset : 0,
-    onStart: onAnimationStart,
-    onFrame: onAnimationFrame,
-  })
   const transContainer = useSpring({
     opacity: 1,
     from: { opacity: 0 },
@@ -84,27 +43,9 @@ export default function App({ registry }) {
                 collapsedWidth={siderCollapsedWidth}
                 animationDelay={0}
               />
-              <animated.div
-                className={styles.contentBack}
-                style={{
-                  left: `${siderWidth}px`,
-                  transform: transContentBack.x.interpolate(
-                    (x) => `translate3d(${x}px, 0, 0)`
-                  ),
-                }}
-              ></animated.div>
             </>
           )}
-          <div
-            className={styles.content}
-            style={
-              appOptions.hideNav
-                ? {}
-                : {
-                    marginLeft: contentLeftOffset,
-                  }
-            }
-          >
+          <div className={styles.content}>
             <div id="__spa_content__"></div>
           </div>
         </animated.div>


### PR DESCRIPTION
- make the animation of width changing smooth

- improve performance

![image](https://user-images.githubusercontent.com/5772358/95646671-918ef180-0afd-11eb-901f-a4bc74d9040b.png)

expanding and collapsing the sidebar for one time in six seconds, the left one is controlled by JS and the right one is controlled by CSS