### PR TITLE
ui: display error message instead of stack trace on connect failure

### DIFF
--- a/ui/dashboardApp/index.ts
+++ b/ui/dashboardApp/index.ts
@@ -56,7 +56,7 @@ async function main() {
   } catch (e) {
     Modal.error({
       title: 'Failed to connect to TiDB Dashboard server',
-      content: e.stack,
+      content: '' + e,
       okText: 'Reload',
       onOk: () => window.location.reload(),
     })


### PR DESCRIPTION
The stack trace is useless without source map, and also it is very hard to understand what error is going on without the error message.

(Using `''+e` instead of `e.message` to be compatible with non-Exception errors)