### PR TITLE
keyviz: fix panic in matrix package

### DIFF
--- a/pkg/keyvisual/matrix/axis.go
+++ b/pkg/keyvisual/matrix/axis.go
@@ -182,7 +182,7 @@ func (c *chunk) Reduce(newKeys []string) chunk {
 	endKeys := newKeys[1:]
 	j := 0
 	for i, value := range c.Values {
-		if equal(keys[i], endKeys[j]) {
+		if i > 0 && equal(keys[i], endKeys[j]) {
 			j++
 		}
 		newValues[j] += value

--- a/pkg/keyvisual/matrix/axis_test.go
+++ b/pkg/keyvisual/matrix/axis_test.go
@@ -20,3 +20,31 @@ import (
 var _ = Suite(&testAxisSuite{})
 
 type testAxisSuite struct{}
+
+func (s *testAxisSuite) TestChunkReduce(c *C) {
+	testcases := []struct {
+		keys      []string
+		values    []uint64
+		newKeys   []string
+		newValues []uint64
+	}{
+		{
+			[]string{"", "a", "b", "c", ""},
+			[]uint64{1, 10, 100, 1000},
+			[]string{"", "b", ""},
+			[]uint64{11, 1100},
+		},
+		{
+			[]string{"", "a", "b", "c", ""},
+			[]uint64{1, 10, 100, 1000},
+			[]string{"", ""},
+			[]uint64{1111},
+		},
+	}
+
+	for _, testcase := range testcases {
+		originChunk := createChunk(testcase.keys, testcase.values)
+		reduceChunk := originChunk.Reduce(testcase.newKeys)
+		c.Assert(reduceChunk.Values, DeepEquals, testcase.newValues)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

### What problem does this PR solve?

In the `keyvisual.matrix` package, `chunk.Reduce(keys{"", ""})` will cause a panic.

### What is changed and how it works?

* The original code preset `keys[i] != keys[i+1]`, only `keys{"", ""}` does not match. So make a special judgment on it.
* Add unittests.