### PR TITLE
ui: remove experimental API in checkBrowser.js

### DIFF
--- a/ui/gulpfile.esm.js
+++ b/ui/gulpfile.esm.js
@@ -59,7 +59,7 @@ function updateBrowserList() {
 }
 
 task('gen:browserlist', () => {
-  return src('public/checkBrowser.js')
+  return src('public/compat.js')
     .pipe(updateBrowserList())
     .pipe(dest('public', { overwrite: true }))
 })

--- a/ui/public/checkBrowser.js
+++ b/ui/public/checkBrowser.js
@@ -40,7 +40,7 @@ function checkBrowser() {
     d.getElementsByTagName('a')[0].onclick = function () {
       d.getElementsByTagName('div')[0].style.top = '-60px'
     }
-    document.body.prepend ? document.body.prepend(d) : document.body.insertBefore(d, document.body.firstChild)
+    document.body.insertBefore(d, document.body.firstChild)
   }
 }
 

--- a/ui/public/checkBrowser.js
+++ b/ui/public/checkBrowser.js
@@ -40,7 +40,7 @@ function checkBrowser() {
     d.getElementsByTagName('a')[0].onclick = function () {
       d.getElementsByTagName('div')[0].style.top = '-60px'
     }
-    document.body.prepend(d)
+    document.body.prepend ? document.body.prepend(d) : document.body.insertBefore(d, document.body.firstChild)
   }
 }
 

--- a/ui/public/compat.js
+++ b/ui/public/compat.js
@@ -45,3 +45,20 @@ function checkBrowser() {
 }
 
 checkBrowser()
+
+// Dealing with compatibility issues manually for special cases
+
+// Object.entries
+// see https://github.com/pingcap-incubator/tidb-dashboard/issues/770
+// polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+if (!Object.entries) {
+  Object.entries = function( obj ){
+    var ownProps = Object.keys( obj ),
+      i = ownProps.length,
+      resArray = new Array(i); // preallocate the Array
+    while (i--)
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
+  };
+}

--- a/ui/public/diagnoseReport.html
+++ b/ui/public/diagnoseReport.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script src="%PUBLIC_URL%/checkBrowser.js"></script>
+    <script src="%PUBLIC_URL%/compat.js"></script>
     <div id="root"></div>
   </body>
 </html>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -91,7 +91,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script src="%PUBLIC_URL%/checkBrowser.js"></script>
+    <script src="%PUBLIC_URL%/compat.js"></script>
     <div id="dashboard_page_spinner"><div class="dot-flashing"></div></div>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5772358/96822162-01856c00-145c-11eb-9c52-ae2ddf5d6aca.png)


---

close #770 

when testing the related issue on the low version of the Firefox, we found that alert from checkBrowser.js can't appear for the experimental API checkBrowser.js uses is not supported by these low version browsers.
