### PR TITLE
ui: show disk usage information for statement and slow query

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -43,6 +43,7 @@ type SlowQuery struct {
 	ProcessTime float64 `gorm:"column:Process_time" json:"process_time"`
 
 	MemoryMax  int  `gorm:"column:Mem_max" json:"memory_max"`
+	DiskMax    int  `gorm:"column:Disk_max" json:"disk_max"`
 	TxnStartTS uint `gorm:"column:Txn_start_ts" json:"txn_start_ts"`
 
 	// Detail

--- a/pkg/apiserver/statement/models.go
+++ b/pkg/apiserver/statement/models.go
@@ -84,6 +84,8 @@ type Model struct {
 	AggSumBackoffTimes       int    `json:"sum_backoff_times" agg:"SUM(sum_backoff_times)"`
 	AggAvgMem                int    `json:"avg_mem" agg:"ROUND(SUM(exec_count * avg_mem) / SUM(exec_count))"`
 	AggMaxMem                int    `json:"max_mem" agg:"MAX(max_mem)"`
+	AggAvgDisk               int    `json:"avg_disk" agg:"ROUND(SUM(exec_count * avg_disk) / SUM(exec_count))"`
+	AggMaxDisk               int    `json:"max_disk" agg:"MAX(max_disk)"`
 	AggAvgAffectedRows       int    `json:"avg_affected_rows" agg:"ROUND(SUM(exec_count * avg_affected_rows) / SUM(exec_count))"`
 	AggFirstSeen             int    `json:"first_seen" agg:"UNIX_TIMESTAMP(MIN(first_seen))"`
 	AggLastSeen              int    `json:"last_seen" agg:"UNIX_TIMESTAMP(MAX(last_seen))"`

--- a/ui/lib/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
+++ b/ui/lib/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
@@ -29,6 +29,10 @@ export default function TabBasic({ data }: ITabBasicProps) {
       key: 'memory_max',
       value: getValueFormat('bytes')(data.memory_max || 0, 1),
     },
+    {
+      key: 'disk_max',
+      value: getValueFormat('bytes')(data.disk_max || 0, 1),
+    },
     { key: 'instance', value: data.instance },
     { key: 'connection_id', value: data.connection_id },
     { key: 'user', value: data.user },

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -13,6 +13,8 @@ slow_query:
     query_time_tooltip: Execution time of the query
     memory_max: Max Memory
     memory_max_tooltip: Maximum memory usage of the query
+    disk_max: Max Disk
+    disk_max_tooltip: Maximum disk usage of the query
     digest: Query Template ID
     digest_tooltip: a.k.a. Query digest
     is_internal: Is Internal?

--- a/ui/lib/apps/SlowQuery/translations/zh.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh.yaml
@@ -14,6 +14,8 @@ slow_query:
     query_time_tooltip: 该 SQL 查询总的执行时间
     memory_max: 最大内存
     memory_max_tooltip: 该 SQL 查询执行时占用的最大内存空间
+    disk_max: 最大磁盘空间
+    disk_max_tooltip: 该 SQL 查询执行时占用的最大磁盘空间
     digest: SQL 模板 ID
     digest_tooltip: SQL 模板的唯一标识（SQL 指纹）
     is_internal: 是否为内部 SQL 查询

--- a/ui/lib/apps/SlowQuery/utils/tableColumns.tsx
+++ b/ui/lib/apps/SlowQuery/utils/tableColumns.tsx
@@ -51,6 +51,7 @@ export function slowQueryColumns(
     tcf.bar.single('compile_time', 's', rows),
     tcf.bar.single('process_time', 's', rows),
     tcf.bar.single('memory_max', 'bytes', rows),
+    tcf.bar.single('disk_max', 'bytes', rows),
 
     tcf.textWithTooltip('txn_start_ts', rows),
     // success columnn

--- a/ui/lib/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
+++ b/ui/lib/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
@@ -66,6 +66,14 @@ export default function TabBasic({ data }: ITabBasicProps) {
       key: 'max_mem',
       value: getValueFormat('bytes')(data.max_mem || 0, 1),
     },
+    {
+      key: 'avg_disk',
+      value: getValueFormat('bytes')(data.avg_disk || 0, 1),
+    },
+    {
+      key: 'max_disk',
+      value: getValueFormat('bytes')(data.max_disk || 0, 1),
+    },
   ]
   const columns = valueColumns('statement.fields.')
   return (

--- a/ui/lib/apps/Statement/translations/en.yaml
+++ b/ui/lib/apps/Statement/translations/en.yaml
@@ -74,6 +74,10 @@ statement:
     avg_mem_tooltip: Memory usage of single query
     max_mem: Max Memory
     max_mem_tooltip: Maximum memory usage of single query
+    avg_disk: Mean Disk
+    avg_disk_tooltip: Disk usage of single query
+    max_disk: Max Disk
+    max_disk_tooltip: Maximum disk usage of single query
     index_names: Index Name
     index_names_tooltip: The name of the used index
     first_seen: First Seen

--- a/ui/lib/apps/Statement/translations/zh.yaml
+++ b/ui/lib/apps/Statement/translations/zh.yaml
@@ -73,6 +73,10 @@ statement:
     avg_mem_tooltip: 单条 SQL 查询的消耗内存大小
     max_mem: 最大内存
     max_mem_tooltip: 最大单条 SQL 查询消耗内存大小
+    avg_disk: 平均磁盘空间
+    avg_disk_tooltip: 单条 SQL 查询占用的磁盘空间大小
+    max_disk: 最大磁盘空间
+    max_disk_tooltip: 最大单条 SQL 查询占用的磁盘空间大小
     table_names: 表名
     index_names: 索引名
     index_names_tooltip: SQL 执行时使用的索引名称

--- a/ui/lib/apps/Statement/utils/tableColumns.tsx
+++ b/ui/lib/apps/Statement/utils/tableColumns.tsx
@@ -73,6 +73,7 @@ export const derivedFields = {
   ),
   avg_txn_retry: genDerivedBarSources('avg_txn_retry', 'max_txn_retry'),
   avg_mem: genDerivedBarSources('avg_mem', 'max_mem'),
+  avg_disk: genDerivedBarSources('avg_disk', 'max_disk'),
   sum_errors: ['sum_errors', 'sum_warnings'],
   related_schemas: ['table_names'],
 }
@@ -163,6 +164,7 @@ export function statementColumns(
       columnActionsMode: ColumnActionsMode.clickable,
     },
     avgMaxColumn(tcf, 'avg_mem', 'bytes', rows),
+    avgMaxColumn(tcf, 'avg_disk', 'bytes', rows),
     errorsWarningsColumn(tcf, rows),
     avgMaxColumn(tcf, 'parse_latency', 'ns', rows),
     avgMaxColumn(tcf, 'compile_latency', 'ns', rows),


### PR DESCRIPTION
close #739 

Screenshots:

![image](https://user-images.githubusercontent.com/1284531/96843064-75d20680-1480-11eb-8122-7e8251bd6a09.png)

![image](https://user-images.githubusercontent.com/1284531/96843099-81bdc880-1480-11eb-96d5-24160f3e95b0.png)

These new columns seem to only exist in the new TiDB version, but I don't think we need to handle the compatibility problem before the dashboard has a standalone deployment mode, right?