### PR TITLE
fix can't handle the portal event correctly

### DIFF
--- a/ui/dashboardApp/index.ts
+++ b/ui/dashboardApp/index.ts
@@ -150,17 +150,22 @@ async function webPageStart() {
 async function main() {
   if (routing.isPortalPage()) {
     // the portal page is only used to receive options
-    window.addEventListener(
-      'message',
-      (event) => {
-        const { token, lang, hideNav, redirectPath } = event.data
-        auth.setAuthToken(token)
-        saveAppOptions({ hideNav, lang })
-        window.location.hash = `#${redirectPath}`
-        window.location.reload()
-      },
-      { once: true }
-    )
+    function handlePortalEvent(event) {
+      const { type, token, lang, hideNav, redirectPath } = event.data
+      // the event type must be "DASHBOARD_PORTAL_EVENT"
+      if (type !== 'DASHBOARD_PORTAL_EVENT') {
+        return
+      }
+
+      auth.setAuthToken(token)
+      saveAppOptions({ hideNav, lang })
+      window.location.hash = `#${redirectPath}`
+      window.location.reload()
+
+      window.removeEventListener('message', handlePortalEvent)
+    }
+
+    window.addEventListener('message', handlePortalEvent)
     return
   }
 

--- a/ui/tests/config-portal-test.html
+++ b/ui/tests/config-portal-test.html
@@ -18,6 +18,7 @@
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1OTIwMjUzMjgsIm9yaWdfaWF0IjoxNTkxOTM4OTI4LCJwIjoibkZyZGh1OXlxdnNOSnBXS1daUUlUTkRPakJFMTc4eExQaXc3Y1g4eGxrNFlxMXBRWXVUU1BLVHdNQXIwM2VDajhvTnJuWDc5ZEFDQWZtblBzZXcwaXhnQWdaR1kveU1pMXNqUUc4L1VkMy9McDJKUTN5elMifQ.ynPM1S2jOBvnEcRJgZK-FEaUuhNCI16GCUXKdYs9T18'
         dashboard.contentWindow.postMessage(
           {
+            type: 'DASHBOARD_PORTAL_EVENT',
             token,
             lang: 'en',
             hideNav: true,


### PR DESCRIPTION
What's the issue: 

We don't judge whether the event is sent by ourselves in the message handler, so if anyone else posts a message before ourselves, the message handler would get the wrong data, and the handler quits because it just handles the message once.

After using the EventEmitter2, inside the EventEmitter2, it uses a method - setImmediate ([ref](https://github.com/EventEmitter2/EventEmitter2/blob/master/lib/eventemitter2.js#L17)), but it's not a standard API, so when building, wepback (or may babel) import polyfill for it. In the implementation of setImmediate polyfill, it calls the `postMessage()` ([ref](https://github.com/YuzuJS/setImmediate/blob/master/setImmediate.js#L93)) to make the portal message handler doesn't work anymore.

Solution: 

Add an extra field `type: "DASHBAORAD_PORTAL_EVENT"` to indicate it's an event sent by ourselves.

Next work: add test for portal page #990 