### PR TITLE
fix(keyviz): table name can't display within 1min of starting in keyviz

### DIFF
--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -67,11 +67,11 @@ func (s *tidbLabelStrategy) ReloadConfig(cfg *config.KeyVisualConfig) {}
 func (s *tidbLabelStrategy) Background(ctx context.Context) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
-	for {
+	for ; true; <-ticker.C {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		default:
 			s.updateMap(ctx)
 		}
 	}


### PR DESCRIPTION
Fix the problem that the table name can't display within 1min of starting in keyviz.