### PR TITLE
rest: include code and message in log message

### DIFF
--- a/util/rest/error.go
+++ b/util/rest/error.go
@@ -89,7 +89,10 @@ func ErrorHandlerFn() gin.HandlerFunc {
 		log.Warn("Error when handling request",
 			zap.String("uri", c.Request.RequestURI),
 			zap.String("remoteAddr", c.Request.RemoteAddr),
-			zap.String("errorFullText", errResponse.FullText))
+			zap.String("errorCode", errResponse.Code),
+			zap.String("errorMessage", errResponse.Message),
+			zap.String("errorFullText", errResponse.FullText), // empty unless on debug level
+		)
 		c.AbortWithStatusJSON(statusCode, errResponse)
 	}
 }


### PR DESCRIPTION
Currently the reason for request failures isn't very clear. This might help.

<img width="1469" height="266" alt="image" src="https://github.com/user-attachments/assets/c217822d-e56a-4188-a4c5-25fbf143e0b8" />
