### PR TITLE
topsql: use number instead of bool to set minimal window interval value and add new data source parameters

### DIFF
--- a/pkg/apiserver/topsql/service.go
+++ b/pkg/apiserver/topsql/service.go
@@ -83,6 +83,7 @@ type GetSummaryRequest struct {
 	GroupBy      string `json:"group_by"`
 	OrderBy      string `json:"order_by"`
 	Window       string `json:"window"`
+	DataSource   string `json:"data_source"`
 }
 
 type SummaryResponse struct {

--- a/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
@@ -3709,6 +3709,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @summary Get summaries
+         * @param {string} [dataSource] 
          * @param {string} [end] 
          * @param {string} [groupBy] 
          * @param {string} [instance] 
@@ -3720,7 +3721,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        topsqlSummaryGet: async (end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        topsqlSummaryGet: async (dataSource?: string, end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/topsql/summary`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3735,6 +3736,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             // authentication JwtAuth required
             await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (dataSource !== undefined) {
+                localVarQueryParameter['data_source'] = dataSource;
+            }
 
             if (end !== undefined) {
                 localVarQueryParameter['end'] = end;
@@ -5215,6 +5220,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Get summaries
+         * @param {string} [dataSource] 
          * @param {string} [end] 
          * @param {string} [groupBy] 
          * @param {string} [instance] 
@@ -5226,8 +5232,8 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async topsqlSummaryGet(end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TopsqlSummaryResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.topsqlSummaryGet(end, groupBy, instance, instanceType, orderBy, start, top, window, options);
+        async topsqlSummaryGet(dataSource?: string, end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TopsqlSummaryResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.topsqlSummaryGet(dataSource, end, groupBy, instance, instanceType, orderBy, start, top, window, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -6288,6 +6294,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         /**
          * 
          * @summary Get summaries
+         * @param {string} [dataSource] 
          * @param {string} [end] 
          * @param {string} [groupBy] 
          * @param {string} [instance] 
@@ -6299,8 +6306,8 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        topsqlSummaryGet(end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options?: any): AxiosPromise<TopsqlSummaryResponse> {
-            return localVarFp.topsqlSummaryGet(end, groupBy, instance, instanceType, orderBy, start, top, window, options).then((request) => request(axios, basePath));
+        topsqlSummaryGet(dataSource?: string, end?: string, groupBy?: string, instance?: string, instanceType?: string, orderBy?: string, start?: string, top?: string, window?: string, options?: any): AxiosPromise<TopsqlSummaryResponse> {
+            return localVarFp.topsqlSummaryGet(dataSource, end, groupBy, instance, instanceType, orderBy, start, top, window, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -7504,6 +7511,13 @@ export interface DefaultApiTopsqlInstancesGetRequest {
  * @interface DefaultApiTopsqlSummaryGetRequest
  */
 export interface DefaultApiTopsqlSummaryGetRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof DefaultApiTopsqlSummaryGet
+     */
+    readonly dataSource?: string
+
     /**
      * 
      * @type {string}
@@ -8758,7 +8772,7 @@ export class DefaultApi extends BaseAPI {
      * @memberof DefaultApi
      */
     public topsqlSummaryGet(requestParameters: DefaultApiTopsqlSummaryGetRequest = {}, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).topsqlSummaryGet(requestParameters.end, requestParameters.groupBy, requestParameters.instance, requestParameters.instanceType, requestParameters.orderBy, requestParameters.start, requestParameters.top, requestParameters.window, options).then((request) => request(this.axios, this.basePath));
+        return DefaultApiFp(this.configuration).topsqlSummaryGet(requestParameters.dataSource, requestParameters.end, requestParameters.groupBy, requestParameters.instance, requestParameters.instanceType, requestParameters.orderBy, requestParameters.start, requestParameters.top, requestParameters.window, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -3505,6 +3505,11 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "name": "data_source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "name": "end",
                         "in": "query"
                     },

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/TopSQL/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/TopSQL/context.ts
@@ -29,6 +29,7 @@ class DataSource implements ITopSQLDataSource {
     start?: string,
     top?: string,
     window?: string,
+    dataSource?: string,
     options?: ReqConfig
   ) {
     return client.getInstance().topsqlSummaryGet(
@@ -40,7 +41,8 @@ class DataSource implements ITopSQLDataSource {
         orderBy,
         start,
         top,
-        window
+        window,
+        dataSource
       },
       options
     )

--- a/ui/packages/tidb-dashboard-for-op/src/apps/TopSQL/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/TopSQL/context.ts
@@ -29,6 +29,7 @@ class DataSource implements ITopSQLDataSource {
     start?: string,
     top?: string,
     window?: string,
+    dataSource?: string,
     options?: ReqConfig
   ) {
     return client.getInstance().topsqlSummaryGet(
@@ -40,7 +41,8 @@ class DataSource implements ITopSQLDataSource {
         orderBy,
         start,
         top,
-        window
+        window,
+        dataSource
       },
       options
     )

--- a/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/context/index.ts
@@ -33,6 +33,7 @@ export interface ITopSQLDataSource {
     start?: string,
     top?: string,
     window?: string,
+    dataSource?: string,
     options?: ReqConfig
   ): AxiosPromise<TopsqlSummaryResponse>
 }
@@ -59,7 +60,8 @@ export interface ITopSQLConfig {
   showGroupBy?: boolean
   showGroupByRegion?: boolean
   showOrderBy?: boolean
-  limitMinInterval?: boolean
+  minWindowInterval?: number
+  dataSource?: string
 }
 
 export interface ITopSQLContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/pages/List/List.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/pages/List/List.tsx
@@ -123,9 +123,10 @@ export function TopSQLList() {
       const windowSize = Math.ceil(
         (CHART_BAR_WIDTH * (max - min)) / screenWidth
       )
-      const finalWindowSize = ctx?.cfg.limitMinInterval
-        ? Math.max(windowSize, 60)
-        : windowSize
+      const finalWindowSize =
+        ctx?.cfg.minWindowInterval !== undefined
+          ? Math.max(windowSize, ctx.cfg.minWindowInterval)
+          : windowSize
       setTimeWindowSize(finalWindowSize)
       return finalWindowSize
     }
@@ -530,13 +531,18 @@ const useTopSQLData = (
         setIsLoading(true)
         const resp = await ctx!.ds.topsqlSummaryGet(
           String(end),
-          _instance.instance_type === 'tidb' ? AggLevel.Query : groupBy,
+          ctx?.cfg.showGroupBy === true
+            ? _instance.instance_type === 'tidb'
+              ? AggLevel.Query
+              : groupBy
+            : undefined,
           _instance.instance,
           _instance.instance_type,
-          orderBy,
+          ctx?.cfg.showOrderBy === true ? orderBy : undefined,
           String(start),
           String(limit),
-          `${timeWindowSize}s`
+          `${timeWindowSize}s`,
+          ctx?.cfg.dataSource
         )
         dataResp = resp.data
       } finally {


### PR DESCRIPTION
## Change limitMinInterval parameter
Previous version use limitMinInterval bool context parameter to control topsql minimal window interval value:
true: minimal window interval value should be >= 1 minute
false/undefined: no limit for window interval value

However, it is not convenient to set the minimal window interval values to 15s/30s or other values. Thus, this PR use a number type parameter minWindowInterval:
valueA: minimal window interval value should be >= valueA seconds
undefined: no limit for window interval value

## Add new data source parameter
Somethimes, we need to explicit specify the data source of topsql data: "vm" or "deltalake": when we both have "vm" or "deltalake" storage.

No any UI changes for this PR, since the default config values are both undefined for op and cloud.
