### PR TITLE
topsql: Fix table info not listed when group by non-query and order by non-cpu

### DIFF
--- a/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/pages/List/ListTable.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/TopSQL/pages/List/ListTable.tsx
@@ -318,6 +318,9 @@ function useTableData(records: any[], orderBy: OrderBy) {
     if (!records) {
       return { data: [], capacity: 0 }
     }
+    const sum = (arr?: Array<number>): number =>
+      (arr ?? []).reduce((acc, v) => acc + (v || 0), 0)
+
     let capacity = 0
     const d = records
       .map((r) => {
@@ -334,12 +337,13 @@ function useTableData(records: any[], orderBy: OrderBy) {
           })
         })
 
-        // For SummaryByItem (groupBy table or schema)
-        if (r.cpu_time_ms_sum && (r.text?.length ?? 0) > 0) {
-          cpuTime = r.cpu_time_ms_sum
-          // If network_bytes_sum or logical_io_bytes_sum exist, use them
-          networkBytes = r.network_bytes_sum || networkBytes
-          logicalIoBytes = r.logical_io_bytes_sum || logicalIoBytes
+        // For SummaryByItem (groupBy table / schema / region)
+        // Note: backend may omit unrelated fields depending on orderBy, so avoid using
+        // cpu_time_ms_sum as the "is summary-by" guard.
+        if ((r.text?.length ?? 0) > 0) {
+          cpuTime = r.cpu_time_ms_sum ?? sum(r.cpu_time_ms)
+          networkBytes = r.network_bytes_sum ?? sum(r.network_bytes)
+          logicalIoBytes = r.logical_io_bytes_sum ?? sum(r.logical_io_bytes)
         }
 
         // Calculate capacity based on the selected orderBy dimension


### PR DESCRIPTION
**Since orderBy listbox is not shown by default, thus no actual UI changes for this PR.**
Fix TopSQL list table showing empty results when groupBy is not query and orderBy is not cpu.
The table previously treated summary-by rows as valid only when cpu_time_ms_sum was present/non-zero, so for network/logical_io ordering it could skip aggregation and then filter out all rows as zero. We now detect summary-by rows by text and compute cpu/network/logical_io totals using *_sum when available, otherwise falling back to summing the corresponding time-series arrays.