### PR TITLE
chore: update Go to 1.25.7 for security fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:
@@ -61,7 +61,7 @@ jobs:
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/manual-create-pd-pr.yaml
+++ b/.github/workflows/manual-create-pd-pr.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ matrix.branch }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/upload-e2e-snapshots.yaml
+++ b/.github/workflows/upload-e2e-snapshots.yaml
@@ -45,7 +45,7 @@ jobs:
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-dashboard
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module scripts
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe


### PR DESCRIPTION
## Issue
Issue Number: ref #1871

## Summary
- bump the project Go version from 1.25.5 to 1.25.7 in the root and scripts modules
- pin GitHub Actions workflows to Go 1.25.7 so CI and release builds pick up the fixed stdlib
- keep all Go dependencies unchanged on master

## Testing
- /Users/huyibin/.gvm/gos/go1.25/bin/go test -v ./pkg/... ./util/...
- /Users/huyibin/.gvm/gos/go1.25/bin/go build -o /tmp/tidb-dashboard-master-issue1871 ./cmd/tidb-dashboard
