### PR TITLE
Fix linter warnings

### DIFF
--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -254,7 +254,7 @@ func (s *Service) heatmaps(c *gin.Context) {
 		}
 		endTime = time.Unix(tsSec, 0)
 	}
-	if !(startTime.Before(endTime) && (endKey == "" || startKey < endKey)) {
+	if !startTime.Before(endTime) || (endKey != "" && startKey >= endKey) {
 		c.JSON(http.StatusBadRequest, "bad request")
 		return
 	}

--- a/util/reflectutil/field_test.go
+++ b/util/reflectutil/field_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestIsFieldExported(t *testing.T) {
-	//nolint:structcheck
 	type f struct {
 		a   string //nolint:unused
 		B   string


### PR DESCRIPTION
```
$ ./scripts/lint.sh
+ Check golangci-lint binary
+ Run lints for Go source code
WARN [runner] Changes related to "staticcheck" are skipped for the file "/home/dvaneeden/dev/pingcap/tidb-dashboard/pkg/keyvisual/service.go": conflicting edits from staticcheck and staticcheck on /home/dvaneeden/dev/pingcap/tidb-dashboard/pkg/keyvisual/service.go
first edits:
--- base
+++ staticcheck
@@ -254,7 +254,7 @@
 		}
 		endTime = time.Unix(tsSec, 0)
 	}
-	if !(startTime.Before(endTime) && (endKey == "" || startKey < endKey)) {
+	if (!startTime.Before(endTime) || (endKey != "" && startKey >= endKey)) {
 		c.JSON(http.StatusBadRequest, "bad request")
 		return
 	}

second edits:
--- base
+++ staticcheck
@@ -254,7 +254,7 @@
 		}
 		endTime = time.Unix(tsSec, 0)
 	}
-	if !(startTime.Before(endTime) && (endKey == "" || startKey < endKey)) {
+	if (!startTime.Before(endTime) || endKey != "" && startKey >= endKey) {
 		c.JSON(http.StatusBadRequest, "bad request")
 		return
 	}
WARN [runner/nolint_filter] Found unknown linters in //nolint directives: structcheck
0 issues.
+ Clean up go mod
```