### PR TITLE
chore: update Go version to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-dashboard
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module scripts
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe


### PR DESCRIPTION
## Issue
Issue Number: ref #1878

## Summary
- bump the project Go version from 1.25.7 to 1.25.8 in the root module
- bump the scripts module Go version from 1.25.7 to 1.25.8
- keep all other dependency and workflow changes out of this PR

## Testing
- GOCACHE=$(pwd)/.gocache GOMODCACHE=$(pwd)/.gomodcache /Users/huyibin/.gvm/gos/go1.25/bin/go test -v ./pkg/... ./util/...
- GOCACHE=$(pwd)/.gocache GOMODCACHE=$(pwd)/.gomodcache /Users/huyibin/.gvm/gos/go1.25/bin/go build -o /tmp/tidb-dashboard-release-8.5-issue1878 ./cmd/tidb-dashboard
