### PR TITLE
fix lint error

### DIFF
--- a/pkg/apiserver/diagnose/query.go
+++ b/pkg/apiserver/diagnose/query.go
@@ -272,7 +272,7 @@ func (t totalTimeByLabelsTableDef) genSumarySQLs(totalTime float64, startTime, e
 			fields.WriteString(",")
 			tbls += "join "
 		}
-		fields.WriteString(fmt.Sprintf("t%v.*", i))
+		fmt.Fprintf(&fields, "t%v.*", i)
 		tbls += fmt.Sprintf(" (%s) as t%v ", sql, i)
 	}
 	joinSQL := fmt.Sprintf("select %v from %v", fields.String(), tbls)
@@ -296,11 +296,11 @@ func (t totalTimeByLabelsTableDef) genDetailSQLs(totalTime float64, startTime, e
 		sql := fmt.Sprintf("select `%[5]s`, max(value) as max_value from metrics_schema.%[1]s_duration where time >= '%[2]s' and time < '%[3]s' and quantile=%[4]f group by `%[5]s`",
 			t.tbl, startTime, endTime, quantile, strings.Join(t.labels, "`,`"))
 		sqls = append(sqls, sql)
-		joinSQL.WriteString(fmt.Sprintf(",t%v.max_value", i+2))
+		fmt.Fprintf(&joinSQL, ",t%v.max_value", i+2)
 	}
 	joinSQL.WriteString(" from ")
 	for i, sql := range sqls {
-		joinSQL.WriteString(fmt.Sprintf(" (%s) as t%v ", sql, i))
+		fmt.Fprintf(&joinSQL, " (%s) as t%v ", sql, i)
 		if i != len(sqls)-1 {
 			joinSQL.WriteString("join ")
 		}
@@ -311,7 +311,7 @@ func (t totalTimeByLabelsTableDef) genDetailSQLs(totalTime float64, startTime, e
 			if i > 0 || j > 0 {
 				joinSQL.WriteString("and ")
 			}
-			joinSQL.WriteString(fmt.Sprintf(" t%v.%s = t%v.%s ", i, label, i+1, label))
+			fmt.Fprintf(&joinSQL, " t%v.%s = t%v.%s ", i, label, i+1, label)
 		}
 	}
 	joinSQL.WriteString(" order by t0.total desc")
@@ -399,7 +399,7 @@ func (t totalValueAndTotalCountTableDef) genSumarySQLs(startTime, endTime string
 			fields.WriteString(",")
 			tbls += "join "
 		}
-		fields.WriteString(fmt.Sprintf("t%v.*", i))
+		fmt.Fprintf(&fields, "t%v.*", i)
 		tbls += fmt.Sprintf(" (%s) as t%v ", sql, i)
 	}
 	joinSQL := fmt.Sprintf("select %v from %v", fields.String(), tbls)
@@ -422,11 +422,11 @@ func (t totalValueAndTotalCountTableDef) genDetailSQLs(startTime, endTime string
 		sql := fmt.Sprintf("select `%[5]s`, max(value) as max_value from metrics_schema.%[1]s where time >= '%[2]s' and time < '%[3]s' and quantile=%[4]f group by `%[5]s`",
 			t.tbl, startTime, endTime, quantile, strings.Join(t.labels, "`,`"))
 		sqls = append(sqls, sql)
-		joinSQL.WriteString(fmt.Sprintf(",t%v.max_value", i+2))
+		fmt.Fprintf(&joinSQL, ",t%v.max_value", i+2)
 	}
 	joinSQL.WriteString(" from ")
 	for i, sql := range sqls {
-		joinSQL.WriteString(fmt.Sprintf(" (%s) as t%v ", sql, i))
+		fmt.Fprintf(&joinSQL, " (%s) as t%v ", sql, i)
 		if i != len(sqls)-1 {
 			joinSQL.WriteString("join ")
 		}
@@ -437,7 +437,7 @@ func (t totalValueAndTotalCountTableDef) genDetailSQLs(startTime, endTime string
 			if i > 0 || j > 0 {
 				joinSQL.WriteString("and ")
 			}
-			joinSQL.WriteString(fmt.Sprintf(" t%v.%s = t%v.%s ", i, label, i+1, label))
+			fmt.Fprintf(&joinSQL, " t%v.%s = t%v.%s ", i, label, i+1, label)
 		}
 	}
 	joinSQL.WriteString(" order by t0.total desc")

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -400,16 +400,15 @@ export default function StatementsOverview() {
           data-e2e="statements_table"
         >
           <ScrollablePane>
-            {controller.isDataLoadedSlowly &&
-              (ctx?.cfg.instantQuery ?? true) && (
-                <Card noMarginBottom noMarginTop>
-                  <Alert
-                    message={t('statement.pages.overview.slow_load_info')}
-                    type="info"
-                    showIcon
-                  />
-                </Card>
-              )}
+            {controller.isDataLoadedSlowly && (ctx?.cfg.instantQuery ?? true) && (
+              <Card noMarginBottom noMarginTop>
+                <Alert
+                  message={t('statement.pages.overview.slow_load_info')}
+                  type="info"
+                  showIcon
+                />
+              </Card>
+            )}
             <Card noMarginBottom noMarginTop>
               <p className="ant-form-item-extra">
                 {dataTimeRange && (ctx?.cfg.showActualTimeRange ?? true) && (

--- a/util/reflectutil/tag.go
+++ b/util/reflectutil/tag.go
@@ -8,9 +8,9 @@ import (
 
 // GetFieldsAndTags return fields' tags assign by `tags` parameter.
 func GetFieldsAndTags(obj interface{}, tags []string) []Field {
-	fieldTags := []Field{}
 	t := reflect.TypeOf(obj)
 	fNum := t.NumField()
+	fieldTags := make([]Field, 0, fNum)
 	for i := range fNum {
 		f := Field{Tags: map[string]string{}}
 		structField := t.Field(i)


### PR DESCRIPTION
Fix lint error:
```
Run make dev
scripts/lint.sh
+ Check golangci-lint binary
  - Download golangci-lint binary
golangci/golangci-lint info checking GitHub for tag 'v2.11.3'
golangci/golangci-lint info found version: 2.11.3 for v2.11.3/linux/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
+ Run lints for Go source code
Error: util/reflectutil/tag.go:11:2: Consider preallocating fieldTags with capacity fNum (prealloc)
	fieldTags := []Field{}
	^
1 issues:
* prealloc: 1
make: *** [Makefile:58: lint] Error 1
Error: Process completed with exit code 2.
```

As well as committing auto-modified `pkg/apiserver/diagnose/query.go` with `make dev`