### PR TITLE
feat: add RU V2 fields to slow query and statement for clinic cloud

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
@@ -209,6 +209,7 @@ export const ctx: (cfg: Partial<ISlowQueryConfig>) => ISlowQueryContext = (
       showResourceGroupFilter: true,
       showDownloadSlowQueryDBFile: true,
       showInternalFilter: true,
+      showRuV2: true,
       ...cfg
     }
   }

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
@@ -184,6 +184,7 @@ export const ctx: (cfg: Partial<IStatementConfig>) => IStatementContext = (
     ds: new DataSource(),
     cfg: {
       apiPathBase: client.getBasePath(),
+      showRuV2: true,
       ...cfg
     }
   }

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
@@ -98,6 +98,10 @@ export interface ISlowQueryConfig extends IContextConfig {
 
   // show internal slow queries
   showInternalFilter?: boolean
+
+  // show RU V2 fields (clinic-only: ru_v2, ru_v2_detail columns,
+  // Basic-tab rows, and the dedicated RU V2 Metrics tab)
+  showRuV2?: boolean
 }
 
 export interface ISlowQueryContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
@@ -3,7 +3,10 @@ import { SlowqueryModel } from '@lib/client'
 import { DateTime } from '@lib/components'
 import { getValueFormat } from '@baurine/grafana-value-formats'
 
-export const tabBasicItems = (data: SlowqueryModel) => [
+export const tabBasicItems = (
+  data: SlowqueryModel,
+  options?: { showRuV2?: boolean }
+) => [
   {
     key: 'timestamp',
     value: <DateTime.Calendar unixTimestampMs={(data.timestamp ?? 0) * 1000} />
@@ -35,5 +38,6 @@ export const tabBasicItems = (data: SlowqueryModel) => [
   { key: 'user', value: data.user },
   { key: 'host', value: data.host },
   { key: 'ru', value: data.ru },
+  ...(options?.showRuV2 ? [{ key: 'ru_v2', value: data.ru_v2 }] : []),
   { key: 'resource_group', value: data.resource_group }
 ]

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabRuV2.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabRuV2.tsx
@@ -1,0 +1,157 @@
+import React, { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { getValueFormat } from '@baurine/grafana-value-formats'
+
+import { RequestUnitV2Metrics, SlowqueryModel } from '@lib/client'
+import { CardTable, Pre } from '@lib/components'
+import { valueColumns } from '@lib/utils/tableColumns'
+
+const num = (v: number | undefined, unit: 'short' | 'bytes' = 'short') =>
+  v == null ? '' : getValueFormat(unit)(v, 2)
+
+const mapToCompactJson = (map: Record<string, number> | undefined): string => {
+  if (!map || Object.keys(map).length === 0) return ''
+  return JSON.stringify(map)
+}
+
+/**
+ * Metrics struct rows for the metrics table inside the RU V2 tab.
+ */
+function buildMetricsItems(data: SlowqueryModel) {
+  const m: RequestUnitV2Metrics = data.ru_v2_metrics ?? {}
+  return [
+    { key: 'ru_v2_metrics.total_ru', value: num(m.total_ru) },
+    { key: 'ru_v2_metrics.tidb_ru', value: num(m.tidb_ru) },
+    { key: 'ru_v2_metrics.tikv_ru', value: num(m.tikv_ru) },
+    { key: 'ru_v2_metrics.tiflash_ru', value: num(m.tiflash_ru) },
+    { key: 'ru_v2_metrics.txn_cnt', value: num(m.txn_cnt) },
+    { key: 'ru_v2_metrics.plan_cnt', value: num(m.plan_cnt) },
+    {
+      key: 'ru_v2_metrics.plan_derive_stats_paths',
+      value: num(m.plan_derive_stats_paths)
+    },
+    {
+      key: 'ru_v2_metrics.session_parser_total',
+      value: num(m.session_parser_total)
+    },
+    { key: 'ru_v2_metrics.executor_l1', value: num(m.executor_l1) },
+    { key: 'ru_v2_metrics.executor_l2', value: num(m.executor_l2) },
+    { key: 'ru_v2_metrics.executor_l3', value: num(m.executor_l3) },
+    {
+      key: 'ru_v2_metrics.executor_l5_insert_rows',
+      value: num(m.executor_l5_insert_rows)
+    },
+    {
+      key: 'ru_v2_metrics.result_chunk_cells',
+      value: num(m.result_chunk_cells)
+    },
+    {
+      key: 'ru_v2_metrics.resource_manager_read_cnt',
+      value: num(m.resource_manager_read_cnt)
+    },
+    {
+      key: 'ru_v2_metrics.resource_manager_write_cnt',
+      value: num(m.resource_manager_write_cnt)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_coprocessor_executor_iterations',
+      value: num(m.tikv_coprocessor_executor_iterations)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_coprocessor_response_bytes',
+      value: num(m.tikv_coprocessor_response_bytes, 'bytes')
+    },
+    {
+      key: 'ru_v2_metrics.tikv_coprocessor_executor_work_total',
+      value: mapToCompactJson(m.tikv_coprocessor_executor_work_total)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_storage_processed_keys_get',
+      value: num(m.tikv_storage_processed_keys_get)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_storage_processed_keys_batch_get',
+      value: num(m.tikv_storage_processed_keys_batch_get)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_kv_engine_cache_miss',
+      value: num(m.tikv_kv_engine_cache_miss)
+    },
+    {
+      key: 'ru_v2_metrics.tikv_raftstore_store_write_trigger_wb_bytes',
+      value: num(m.tikv_raftstore_store_write_trigger_wb_bytes, 'bytes')
+    }
+  ]
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <div
+        style={{
+          fontSize: 14,
+          fontWeight: 600,
+          color: '#262626',
+          marginBottom: 8
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function RuV2TabContent({
+  data,
+  schemaColumns
+}: {
+  data: SlowqueryModel
+  schemaColumns: string[]
+}) {
+  const { t } = useTranslation()
+  const schemaSet = new Set(schemaColumns)
+  const v2 = data.ru_v2
+  const v2Detail = data.ru_v2_detail
+
+  // Schema (available_fields) tells us which RU V2 fields the backend can
+  // populate for this cluster tier. Premium only declares `ru_v2`; Starter /
+  // Essential declare `ru_v2`, `ru_v2_detail`, `ru_v2_metrics`. Hide each
+  // section if its field is not in the schema, regardless of the data value.
+  const showV2 = schemaSet.has('ru_v2')
+  const showDetail = schemaSet.has('ru_v2_detail')
+  const showMetrics = schemaSet.has('ru_v2_metrics')
+  const metricsItems = showMetrics ? buildMetricsItems(data) : []
+
+  // Columns: Name + Value only (drop the Description column).
+  const nameValueColumns = valueColumns('slow_query.fields.').slice(0, 2)
+
+  return (
+    <div style={{ padding: '8px 16px' }}>
+      {showV2 && (
+        <Section title={t('slow_query.fields.ru_v2')}>
+          <span style={{ fontSize: 13 }}>{num(v2)}</span>
+        </Section>
+      )}
+
+      {showDetail && (
+        <Section title={t('slow_query.fields.ru_v2_detail')}>
+          <Pre style={{ margin: 0, fontSize: 12, lineHeight: 1.5 }}>
+            {v2Detail ?? ''}
+          </Pre>
+        </Section>
+      )}
+
+      {showMetrics && (
+        <Section title={t('slow_query.fields.ru_v2_metrics_label')}>
+          <CardTable
+            cardNoMargin
+            columns={nameValueColumns}
+            items={metricsItems}
+            extendLastColumn
+          />
+        </Section>
+      )}
+    </div>
+  )
+}

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabs.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabs.tsx
@@ -10,11 +10,13 @@ import { tabBasicItems } from './DetailTabBasic'
 import { tabTimeItems } from './DetailTabTime'
 import { tabCoprItems } from './DetailTabCopr'
 import { tabTxnItems } from './DetailTabTxn'
+import { RuV2TabContent } from './DetailTabRuV2'
 import { useSchemaColumns } from '../../utils/useSchemaColumns'
 import { SlowQueryContext } from '../../context'
 
 export default function DetailTabs({ data }: { data: SlowqueryModel }) {
   const ctx = useContext(SlowQueryContext)
+  const showRuV2 = !!ctx?.cfg.showRuV2
 
   const { t } = useTranslation()
   const { schemaColumns } = useSchemaColumns(
@@ -22,12 +24,22 @@ export default function DetailTabs({ data }: { data: SlowqueryModel }) {
   )
 
   const tabs = useMemo(() => {
+    const schemaSet = new Set(schemaColumns)
+    // Premium tier only declares `ru_v2` in the schema; Starter / Essential
+    // also declare `ru_v2_detail` and `ru_v2_metrics`. Use the presence of the
+    // metrics struct as the tier signal: when absent it's Premium, so the
+    // ru_v2 row stays inside the Basic tab; when present, RU V2 / Detail /
+    // Metrics get their own dedicated tab.
+    const isEssentialLike = schemaSet.has('ru_v2_metrics')
+    const showRuV2InBasic =
+      showRuV2 && schemaSet.has('ru_v2') && !isEssentialLike
+    const showRuV2Tab = showRuV2 && isEssentialLike
     const tbs = [
       {
         key: 'basic',
         title: t('slow_query.detail.tabs.basic'),
         content: () => {
-          const items = tabBasicItems(data)
+          const items = tabBasicItems(data, { showRuV2: showRuV2InBasic })
           const columns = valueColumns('slow_query.fields.')
           return (
             <CardTable
@@ -92,6 +104,15 @@ export default function DetailTabs({ data }: { data: SlowqueryModel }) {
         }
       }
     ]
+    if (showRuV2Tab) {
+      tbs.push({
+        key: 'ru_v2',
+        title: t('slow_query.detail.tabs.ru_v2'),
+        content: () => (
+          <RuV2TabContent data={data} schemaColumns={schemaColumns} />
+        )
+      })
+    }
     if (data.warnings) {
       tbs.push({
         key: 'warnings',
@@ -112,6 +133,6 @@ export default function DetailTabs({ data }: { data: SlowqueryModel }) {
       })
     }
     return tbs
-  }, [schemaColumns, data, t])
+  }, [schemaColumns, data, t, showRuV2])
   return <CardTabs animated={false} tabs={tabs} />
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
@@ -122,6 +122,34 @@ slow_query:
 
     ru: RU
     ru_tooltip: request units
+    ru_v2: RU V2
+    ru_v2_tooltip: Total RU V2 consumed by this query
+    ru_v2_detail: RU V2 Detail
+    ru_v2_detail_tooltip: Per-component RU V2 breakdown (raw)
+    ru_v2_metrics_label: RU V2 Metrics
+    ru_v2_metrics:
+      total_ru: Total RU
+      tidb_ru: TiDB RU
+      tikv_ru: TiKV RU
+      tiflash_ru: TiFlash RU
+      txn_cnt: Transaction Count
+      plan_cnt: Plan Count
+      plan_derive_stats_paths: Plan Derive Stats Paths
+      session_parser_total: Session Parser Total
+      executor_l1: Executor L1
+      executor_l2: Executor L2
+      executor_l3: Executor L3
+      executor_l5_insert_rows: Executor L5 Insert Rows
+      result_chunk_cells: Result Chunk Cells
+      resource_manager_read_cnt: Resource Manager Read Count
+      resource_manager_write_cnt: Resource Manager Write Count
+      tikv_coprocessor_executor_iterations: TiKV Coprocessor Executor Iterations
+      tikv_coprocessor_response_bytes: TiKV Coprocessor Response Bytes
+      tikv_coprocessor_executor_work_total: TiKV Coprocessor Executor Work Total
+      tikv_storage_processed_keys_get: TiKV Storage Processed Keys (Get)
+      tikv_storage_processed_keys_batch_get: TiKV Storage Processed Keys (Batch Get)
+      tikv_kv_engine_cache_miss: TiKV KV Engine Cache Miss
+      tikv_raftstore_store_write_trigger_wb_bytes: TiKV Raftstore Write Trigger WB Bytes
     resource_group: Resource Group
     resource_group_tooltip: The resource group that the query belongs to
     time_queued_by_rc: The total time queued by RC
@@ -174,6 +202,7 @@ slow_query:
       time: Time
       copr: Coprocessor
       txn: Transaction
+      ru_v2: RU V2
       warnings: Warnings
   toolbar:
     schemas:

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
@@ -124,6 +124,34 @@ slow_query:
 
     ru: RU
     ru_tooltip: 资源单位(RU)
+    ru_v2: RU V2
+    ru_v2_tooltip: 本次查询消耗的 RU V2 总量
+    ru_v2_detail: RU V2 明细
+    ru_v2_detail_tooltip: 各组件 RU V2 拆分（原始数据）
+    ru_v2_metrics_label: RU V2 Metrics
+    ru_v2_metrics:
+      total_ru: Total RU
+      tidb_ru: TiDB RU
+      tikv_ru: TiKV RU
+      tiflash_ru: TiFlash RU
+      txn_cnt: 事务数
+      plan_cnt: Plan 数
+      plan_derive_stats_paths: Plan Derive Stats Paths
+      session_parser_total: Session Parser Total
+      executor_l1: Executor L1
+      executor_l2: Executor L2
+      executor_l3: Executor L3
+      executor_l5_insert_rows: Executor L5 插入行数
+      result_chunk_cells: Result Chunk Cells
+      resource_manager_read_cnt: Resource Manager 读次数
+      resource_manager_write_cnt: Resource Manager 写次数
+      tikv_coprocessor_executor_iterations: TiKV Coprocessor Executor 迭代数
+      tikv_coprocessor_response_bytes: TiKV Coprocessor 响应字节
+      tikv_coprocessor_executor_work_total: TiKV Coprocessor Executor 工作总量
+      tikv_storage_processed_keys_get: TiKV Storage Processed Keys (Get)
+      tikv_storage_processed_keys_batch_get: TiKV Storage Processed Keys (Batch Get)
+      tikv_kv_engine_cache_miss: TiKV KV Engine Cache Miss
+      tikv_raftstore_store_write_trigger_wb_bytes: TiKV Raftstore Write Trigger WB Bytes
     resource_group: 资源组
     resource_group_tooltip: SQL 语句所属的资源组
     time_queued_by_rc: RC 等待累积耗时
@@ -178,6 +206,7 @@ slow_query:
       time: 执行时间
       copr: Coprocessor 读取
       txn: 事务
+      ru_v2: RU V2
       warnings: 警告
   toolbar:
     schemas:

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/tableColumns.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/tableColumns.tsx
@@ -125,6 +125,8 @@ export function slowQueryColumns(
     }),
     // resource control
     tcf.bar.single('ru', 'none', rows),
+    tcf.bar.single('ru_v2', 'none', rows),
+    tcf.textWithTooltip('ru_v2_detail', rows),
     tcf.textWithTooltip('resource_group', rows),
     tcf.bar.single('time_queued_by_rc', 's', rows),
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -115,6 +115,10 @@ export interface IStatementConfig extends IContextConfig {
     customAbsoluteRangePicker: boolean
     timeRangeLimit?: number
   }
+
+  // show RU V2 fields (clinic-only: avg_ru_v2 / sum_ru_v2 columns and the
+  // matching Basic-tab rows)
+  showRuV2?: boolean
 }
 
 export interface IStatementContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
@@ -5,7 +5,10 @@ import { getValueFormat } from '@baurine/grafana-value-formats'
 import { StatementModel } from '@lib/client'
 import { DateTime, Pre, ValueWithTooltip, TextWrap } from '@lib/components'
 
-export const tabBasicItems = (data: StatementModel) => [
+export const tabBasicItems = (
+  data: StatementModel,
+  options?: { showRuV2?: boolean }
+) => [
   {
     key: 'table_names',
     value: (
@@ -82,6 +85,26 @@ export const tabBasicItems = (data: StatementModel) => [
     key: 'max_ru',
     value: getValueFormat('short')(data.max_ru || 0, 1)
   },
+  ...(options?.showRuV2
+    ? [
+        {
+          key: 'avg_ru_v2',
+          value: getValueFormat('short')(data.avg_ru_v2 || 0, 1)
+        },
+        {
+          key: 'sum_ru_v2',
+          value: getValueFormat('short')(data.sum_ru_v2 || 0, 1)
+        },
+        {
+          key: 'max_ru_v2',
+          value: getValueFormat('short')(data.max_ru_v2 || 0, 1)
+        },
+        {
+          key: 'sum_ru',
+          value: getValueFormat('short')(data.sum_ru || 0, 1)
+        }
+      ]
+    : []),
   {
     key: 'resource_group',
     value: data.resource_group

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabs.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabs.tsx
@@ -34,7 +34,7 @@ export default function DetailTabs({
       key: 'basic',
       title: t('statement.pages.detail.tabs.basic'),
       content: () => {
-        const items = tabBasicItems(data)
+        const items = tabBasicItems(data, { showRuV2: !!ctx?.cfg.showRuV2 })
         const columns = valueColumns('statement.fields.')
         return (
           <CardTable

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -201,6 +201,12 @@ statement:
     max_ru_tooltip: The maximum number of request units (RU) consumed by the statement
     sum_ru: Total RU
     sum_ru_tooltip: The total number of request units (RU) consumed by the statement
+    avg_ru_v2: Mean RU V2
+    avg_ru_v2_tooltip: The average number of RU V2 consumed by the statement
+    sum_ru_v2: Total RU V2
+    sum_ru_v2_tooltip: The total number of RU V2 consumed by the statement
+    max_ru_v2: Max RU V2
+    max_ru_v2_tooltip: The maximum number of RU V2 consumed by the statement
     avg_time_queued_by_rc: Mean RC Wait Time in Queue
     avg_time_queued_by_rc_tooltip: The average time that the query waits in the resource control's queue (not a wall time)
     max_time_queued_by_rc: Max RC Wait Time in Queue

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -208,6 +208,12 @@ statement:
     max_ru_tooltip: 该 Statement 执行中使用过的最大 RU
     sum_ru: 累积 RU
     sum_ru_tooltip: 该 Statement 的 RU 累积值
+    avg_ru_v2: 平均 RU V2
+    avg_ru_v2_tooltip: Statement 语句的平均 RU V2
+    sum_ru_v2: 累积 RU V2
+    sum_ru_v2_tooltip: 该 Statement 的 RU V2 累积值
+    max_ru_v2: 最大 RU V2
+    max_ru_v2_tooltip: 该 Statement 执行中使用过的最大 RU V2
     avg_time_queued_by_rc: RC 平均等待耗时
     avg_time_queued_by_rc_tooltip: SQL 语句在资源组控制队列中平均等待的时间 (Resource Control)（注：{{distro.tikv}} 会并行处理任务，因此该时间不是自然流逝时间）
     max_time_queued_by_rc: RC 最大等待耗时

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/tableColumns.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/tableColumns.tsx
@@ -102,6 +102,7 @@ export const derivedFields = {
     'max_rocksdb_block_read_byte'
   ),
   avg_ru: genDerivedBarSources('avg_ru', 'max_ru'),
+  avg_ru_v2: genDerivedBarSources('avg_ru_v2', 'max_ru_v2'),
   avg_time_queued_by_rc: genDerivedBarSources(
     'avg_time_queued_by_rc',
     'max_time_queued_by_rc'
@@ -300,6 +301,12 @@ export function statementColumns(
     tcf.textWithTooltip('resource_group', rows),
     avgMaxColumn(tcf, 'avg_ru', 'none', rows),
     tcf.textWithTooltip('sum_ru', rows).patchConfig({
+      minWidth: 100,
+      maxWidth: 300,
+      columnActionsMode: ColumnActionsMode.clickable
+    }),
+    avgMaxColumn(tcf, 'avg_ru_v2', 'none', rows),
+    tcf.textWithTooltip('sum_ru_v2', rows).patchConfig({
       minWidth: 100,
       maxWidth: 300,
       columnActionsMode: ColumnActionsMode.clickable

--- a/ui/packages/tidb-dashboard-lib/src/client/clinic-extensions.d.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/clinic-extensions.d.ts
@@ -1,0 +1,58 @@
+/**
+ * Type augmentation for fields returned by clinic's NGM proxy that aren't
+ * part of the dashboard's own swagger spec.
+ *
+ * This file is NOT generated. Declarations here merge on top of the
+ * interfaces generated into `./models.ts`, so any future re-generation of
+ * the swagger client does NOT overwrite these fields.
+ *
+ * Background: clinic backend (PR pingcap-inc/clinic#1415) returns additional
+ * RU V2 metrics on slow-query / sql-statement responses. The dashboard's own
+ * Go API server does not yet model these fields, so the auto-generated
+ * TypeScript model files don't declare them. This file fills the gap purely
+ * on the TS side for the clinic-cloud deliverable.
+ *
+ * Visibility of these fields in the UI is independently gated by
+ * `ISlowQueryConfig.showRuV2` / `IStatementConfig.showRuV2`, so other
+ * deliverables (standalone TiDB dashboard, clinic-op) are unaffected.
+ */
+import '@lib/client'
+
+declare module '@lib/client' {
+  interface RequestUnitV2Metrics {
+    total_ru?: number
+    tidb_ru?: number
+    tikv_ru?: number
+    tiflash_ru?: number
+    txn_cnt?: number
+    plan_cnt?: number
+    plan_derive_stats_paths?: number
+    session_parser_total?: number
+    executor_l1?: number
+    executor_l2?: number
+    executor_l3?: number
+    executor_l5_insert_rows?: number
+    result_chunk_cells?: number
+    resource_manager_read_cnt?: number
+    resource_manager_write_cnt?: number
+    tikv_coprocessor_executor_iterations?: number
+    tikv_coprocessor_response_bytes?: number
+    tikv_coprocessor_executor_work_total?: Record<string, number>
+    tikv_storage_processed_keys_get?: number
+    tikv_storage_processed_keys_batch_get?: number
+    tikv_kv_engine_cache_miss?: number
+    tikv_raftstore_store_write_trigger_wb_bytes?: number
+  }
+
+  interface SlowqueryModel {
+    ru_v2?: number
+    ru_v2_detail?: string
+    ru_v2_metrics?: RequestUnitV2Metrics
+  }
+
+  interface StatementModel {
+    avg_ru_v2?: number
+    sum_ru_v2?: number
+    max_ru_v2?: number
+  }
+}


### PR DESCRIPTION
## What's Changed

Surface the RU V2 metrics that clinic backend ([clinic#1415](https://github.com/pingcap-inc/clinic/pull/1415)) added to slow query and statement responses. Visibility is gated by a new \`ISlowQueryConfig.showRuV2\` / \`IStatementConfig.showRuV2\` flag, enabled only in \`tidb-dashboard-for-clinic-cloud\`. Standalone TiDB dashboard (\`for-op\`) and clinic on-prem (\`for-clinic-op\`) are unaffected.

For pingcap-inc/clinic-ui#651.

### Slow query
- Optional \`ru_v2\` / \`ru_v2_detail\` columns added to the column selector (registered in \`slowQueryColumns\`; per-tier selectability comes from \`/slow_query/available_fields\` as usual).
- **Premium** (schema declares only \`ru_v2\`): the value is rendered as one extra row in the existing **Basic** info tab.
- **Starter / Essential** (schema declares all three): a dedicated **RU V2** tab is inserted between \`Transaction\` and \`Warnings\`, with three sections:
  - **RU V2** — single numeric value
  - **RU V2 Detail** — full text, wrap-friendly via \`<Pre>\` so long detail strings stay legible
  - **RU V2 Metrics** — name/value table (description column dropped) over the \`RequestUnitV2Metrics\` struct (22 sub-fields)

Per-tier routing is driven by the \`available_fields\` schema rather than the data value, so the Basic-tab row and the dedicated tab never appear together for the same row.

### Statement
- Optional \`avg_ru_v2\` / \`sum_ru_v2\` columns added to the column selector (matched up with existing \`avg_ru\` / \`sum_ru\`).
- Detail **Basic** info tab adds \`avg_ru_v2\` / \`sum_ru_v2\` / \`max_ru_v2\` / \`sum_ru\` rows when the flag is on.

### Types
- New \`ui/packages/tidb-dashboard-lib/src/client/clinic-extensions.d.ts\` augments \`SlowqueryModel\` / \`StatementModel\` (and adds a new \`RequestUnitV2Metrics\` interface) via module augmentation on \`@lib/client\`. This keeps the generated \`models.ts\` untouched, so any future \`make generate_swagger_spec\` run will not overwrite our additions. The dashboard Go models are intentionally **not** modified (these fields are produced by clinic's NGM proxy, not by the dashboard's own backend).

## Test Plan

- [x] On a **Premium** clinic-cloud cluster: SlowQuery list shows the optional \`RU V2\` column; opening a row's Detail shows the value on the **Basic** tab; no separate "RU V2" tab.
- [x] On a **Starter / Essential** clinic-cloud cluster: SlowQuery list shows \`RU V2\` and \`RU V2 Detail\` columns; opening a row's Detail shows the new **RU V2** tab (after \`Transaction\`) with all three sections; \`ru_v2\` is **not** duplicated inside the Basic tab.
- [x] On standalone TiDB dashboard (\`for-op\`) and clinic on-prem (\`for-clinic-op\`): no behavioral change.
- [x] SQL Statement list shows the new \`Mean RU V2\` and \`Total RU V2\` columns; Statement Detail Basic tab shows the four added rows.