### PR TITLE
chore: update Go version to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-dashboard
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module scripts
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe


### PR DESCRIPTION
## Issue
Issue Number: close #1894

## Summary
- bump the project Go version from 1.25.8 to 1.25.10 in the root module
- bump the scripts module Go version from 1.25.8 to 1.25.10
- keep all other dependency and workflow changes out of this PR

## Testing
- not run (per request)
