### PR TITLE
fix: sync generated slow query client artifacts after #1900

### DIFF
--- a/ui/packages/tidb-dashboard-client/src/client/api/models/slowquery-model.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/models/slowquery-model.ts
@@ -363,6 +363,12 @@ export interface SlowqueryModel {
      */
     'ru'?: number;
     /**
+     *
+     * @type {string}
+     * @memberof SlowqueryModel
+     */
+    'session_connect_attrs'?: string;
+    /**
      * 
      * @type {string}
      * @memberof SlowqueryModel
@@ -501,4 +507,3 @@ export interface SlowqueryModel {
      */
     'write_sql_response_total'?: number;
 }
-

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -5377,6 +5377,9 @@
                     "description": "Resource Control",
                     "type": "number"
                 },
+                "session_connect_attrs": {
+                    "type": "string"
+                },
                 "stats": {
                     "type": "string"
                 },

--- a/ui/packages/tidb-dashboard-lib/src/client/models.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/models.ts
@@ -2549,6 +2549,12 @@ export interface SlowqueryModel {
      */
     'ru'?: number;
     /**
+     *
+     * @type {string}
+     * @memberof SlowqueryModel
+     */
+    'session_connect_attrs'?: string;
+    /**
      * 
      * @type {string}
      * @memberof SlowqueryModel
@@ -4550,4 +4556,3 @@ export interface VersionInfo {
      */
     'standalone'?: string;
 }
-


### PR DESCRIPTION
Follow-up to #1900.

Summary:
PR #1900 added the session_connect_attrs field to the backend slow query model, but the generated frontend client artifacts were not synced.

This PR updates the generated files that should reflect that field:
- ui/packages/tidb-dashboard-client/swagger/spec.json
- ui/packages/tidb-dashboard-client/src/client/api/models/slowquery-model.ts
- ui/packages/tidb-dashboard-lib/src/client/models.ts

Validation:
- Re-ran scripts/generate_swagger_spec.sh and confirmed ui/packages/tidb-dashboard-client/swagger/spec.json was stale and needed session_connect_attrs.
- Full frontend OpenAPI regeneration could not be executed in this environment because openapi-generator-cli requires a local Java runtime, which is not installed here.
- Synced the affected generated TS model outputs to match the regenerated spec.
