### PR TITLE
chore: update Go version to 1.25.12

### DIFF
--- a/.github/workflows/manual-create-pd-pr.yaml
+++ b/.github/workflows/manual-create-pd-pr.yaml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ matrix.branch }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.12'
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.12"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.12"
       - name: Load go module cache
         uses: actions/cache@v3
         with:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.12"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/upload-e2e-snapshots.yaml
+++ b/.github/workflows/upload-e2e-snapshots.yaml
@@ -45,7 +45,7 @@ jobs:
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.12"
       - name: Load go module cache
         uses: actions/cache@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-dashboard
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module scripts
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/codeskyblue/go-sh v0.0.0-20200712050446-30169cf553fe


### PR DESCRIPTION
### What problem does this PR solve?

Update the project from Go 1.25.10 to Go 1.25.12.

This keeps the root Go module, the scripts module, and all GitHub workflows aligned on the same Go patch release.

Fixes #1912

### Check List

- [x] go build ./cmd/tidb-dashboard

### Release note

None