### PR TITLE
fix: update toolkit download domain

### DIFF
--- a/scripts/_inc/download_tools.sh
+++ b/scripts/_inc/download_tools.sh
@@ -16,7 +16,10 @@ download_tools() {
 
   if [ ! -e "$BIN/toolkit.tar.gz" ]; then
     echo "  - Downloading toolkit..."
-    curl -L -f -o "$BIN/toolkit.tar.gz" "https://download.pingcap.org/tidb-toolkit-v6.0.0-linux-amd64.tar.gz"
+    curl --http1.1 --retry 5 --retry-all-errors --retry-delay 3 -L -f \
+      -o "$BIN/toolkit.tar.gz.tmp" \
+      "https://download.pingcap.com/tidb-toolkit-v6.0.0-linux-amd64.tar.gz"
+    mv "$BIN/toolkit.tar.gz.tmp" "$BIN/toolkit.tar.gz"
   fi
 
   if [ ! -e "$BIN/dumpling" ]; then


### PR DESCRIPTION
## Summary
- update the TiDB toolkit download URL from download.pingcap.org to download.pingcap.com
- make the toolkit download more robust by forcing HTTP/1.1, adding retries, and writing via a temporary archive
- fix slow query integration assertions so session_connect_attrs is only required when the running TiDB schema exposes it

## Verification
- curl --http1.1 -I --max-time 15 https://download.pingcap.com/tidb-toolkit-v6.0.0-linux-amd64.tar.gz returns HTTP/1.1 200 OK
- go test ./pkg/apiserver/slowquery -count=1
- go test ./tests/integration/slowquery -run '^$' -count=1